### PR TITLE
Fix `SharedResources` not created in `neoInit`

### DIFF
--- a/src/dmqproto/client/mixins/NeoSupport.d
+++ b/src/dmqproto/client/mixins/NeoSupport.d
@@ -631,7 +631,7 @@ template NeoSupport ( )
     private void neoInit ( Neo.Config config,
         Neo.ConnectionNotifier conn_notifier )
     {
-        this.neo = new Neo(config, conn_notifier);
+        this.neo = new Neo(config, conn_notifier, new SharedResources);
         this.blocking = new TaskBlocking;
     }
 


### PR DESCRIPTION
This caused an assertion failure when using the `DmqClient` constructor that accepts the neo and legacy swarm `Config` objects.