### PR TITLE
Flush after sending Continue/Stop/Stopped messages

### DIFF
--- a/src/dmqproto/client/request/internal/Consume.d
+++ b/src/dmqproto/client/request/internal/Consume.d
@@ -511,6 +511,8 @@ private scope class ConsumeHandler
                         payload.addConstant(MessageType_v3.Continue);
                     }
                 );
+
+                this.outer.conn.flush();
             }
 
             this.outer.request_event_dispatcher.signal(this.outer.conn,
@@ -733,6 +735,7 @@ private scope class ConsumeHandler
                                 payload.addConstant(MessageType_v3.Stop);
                             }
                         );
+                        this.outer.conn.flush();
                         break;
 
                     case FiberSignal.StopController:

--- a/src/dmqproto/node/neo/request/Consume.d
+++ b/src/dmqproto/node/neo/request/Consume.d
@@ -372,6 +372,7 @@ public abstract scope class ConsumeProtocol_v3
                 payload.addConstant(MessageType_v3.Stopped);
             }
         );
+        this.ed.flush();
     }
 
     /***************************************************************************


### PR DESCRIPTION
This is performance critical and hopefully solves the problem of low throughput of Consume v3.