### PR TITLE
Flush after sending a batch of records

### DIFF
--- a/src/dmqproto/node/neo/request/Consume.d
+++ b/src/dmqproto/node/neo/request/Consume.d
@@ -331,6 +331,7 @@ public abstract scope class ConsumeProtocol_v3
         switch (event.active)
         {
             case event.active.sent:
+                this.ed.flush();
                 // Records sent: Wait for Consume/Stop feedback, acknowledge
                 // Stop and return true for Continue or false for Stop.
                 switch (this.ed.receiveValue!(MessageType_v3)())


### PR DESCRIPTION
This increases the throughput by approximately 90 times in a test, from 1,400 to 130,000 records/s (700 bytes/record).