### PR TITLE
Update DMD to v1.081 and use wildcards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ env:
         # Make sure beaver is in the PATH
         - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH"
     matrix:
-        - DMD=1.080.0 DIST=xenial F=production AFTER_SCRIPT=1
-        - DMD=1.080.0 DIST=xenial F=devel
-        - DMD=2.070.2.s12 DIST=xenial F=production
-        - DMD=2.070.2.s12 DIST=xenial F=devel
+        - DMD=1.081.* DIST=xenial F=production AFTER_SCRIPT=1
+        - DMD=1.081.* DIST=xenial F=devel
+        - DMD=2.070.2.s* DIST=xenial F=production
+        - DMD=2.070.2.s* DIST=xenial F=devel
 
 install: beaver dlang install
 


### PR DESCRIPTION
> All other tsunami projects use wildcard, under the assumption that a patch release is always safe to upgrade.
> Moreover, we were using an outdated minor release of the D1 compiler (v1.080 instead of v1.081).