### PR TITLE
Test with upstream compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,14 @@ jobs:
           env: DMD=2.070.*.s* F=production
         - <<: *test-matrix
           env: DMD=2.070.2.s* F=devel
+        - <<: *test-matrix
+          env: DMD=2.071.2.s* F=production
+        - <<: *test-matrix
+          env: DMD=2.071.2.s* F=devel
+        - <<: *test-matrix
+          env: DMD=2.078.* F=production
+        - <<: *test-matrix
+          env: DMD=2.078.* F=devel
 
         - stage: D2 Release
           # We need to include the exclusion of D2 tags because this "if"

--- a/src/dmqtest/DmqTestCase.d
+++ b/src/dmqtest/DmqTestCase.d
@@ -21,11 +21,12 @@ module dmqtest.DmqTestCase;
 
 import dmqtest.cases.writers.model.IWriter;
 import dmqtest.cases.checkers.model.IChecker;
+import dmqtest.DmqClient;
 
 import turtle.TestCase;
 
 import ocean.transition;
-
+import ocean.core.Test;
 import ocean.task.Task;
 import ocean.task.Scheduler;
 
@@ -37,8 +38,6 @@ import ocean.task.Scheduler;
 
 abstract class DmqTestCase : TestCase
 {
-    import ocean.core.Test; // makes `test` available in derivatives
-    import dmqtest.DmqClient;
     import dmqtest.util.Record;
 
     /***************************************************************************

--- a/src/dmqtest/cases/Basic.d
+++ b/src/dmqtest/cases/Basic.d
@@ -18,6 +18,8 @@ module dmqtest.cases.Basic;
 
 import dmqtest.DmqTestCase;
 
+import ocean.core.Test;
+
 /******************************************************************************
 
     Most simple push/pop sanity test

--- a/src/dmqtest/cases/Consume.d
+++ b/src/dmqtest/cases/Consume.d
@@ -18,7 +18,10 @@ module dmqtest.cases.Consume;
 
 ******************************************************************************/
 
+import dmqtest.DmqClient;
 import dmqtest.DmqTestCase;
+
+import ocean.core.Test;
 import ocean.transition;
 
 /******************************************************************************

--- a/src/dmqtest/cases/checkers/ConsumeChecker.d
+++ b/src/dmqtest/cases/checkers/ConsumeChecker.d
@@ -23,9 +23,11 @@ module dmqtest.cases.checkers.ConsumeChecker;
 
 *******************************************************************************/
 
+import ocean.core.Test;
 import ocean.task.Task;
 import ocean.transition;
 import dmqtest.cases.checkers.model.IChecker;
+import dmqtest.DmqClient;
 
 /*******************************************************************************
 

--- a/src/dmqtest/cases/checkers/PopChecker.d
+++ b/src/dmqtest/cases/checkers/PopChecker.d
@@ -19,6 +19,11 @@ module dmqtest.cases.checkers.PopChecker;
 *******************************************************************************/
 
 import dmqtest.cases.checkers.model.IChecker;
+import dmqtest.DmqClient;
+
+import ocean.core.Test;
+import ocean.transition;
+
 
 private abstract class PopCheckerBase : IChecker
 {

--- a/src/dmqtest/cases/writers/ProduceMultiWriter.d
+++ b/src/dmqtest/cases/writers/ProduceMultiWriter.d
@@ -19,6 +19,10 @@ module dmqtest.cases.writers.ProduceMultiWriter;
 *******************************************************************************/
 
 import dmqtest.cases.writers.ProduceWriter;
+import dmqtest.DmqClient;
+
+import ocean.transition;
+
 
 class ProduceMultiWriter : ProduceWriterBase
 {

--- a/src/dmqtest/cases/writers/ProduceWriter.d
+++ b/src/dmqtest/cases/writers/ProduceWriter.d
@@ -19,6 +19,10 @@ module dmqtest.cases.writers.ProduceWriter;
 *******************************************************************************/
 
 import dmqtest.cases.writers.model.IWriter;
+import dmqtest.DmqClient;
+
+import ocean.transition;
+
 
 abstract class ProduceWriterBase : IWriter
 {

--- a/src/dmqtest/cases/writers/PushMultiWriter.d
+++ b/src/dmqtest/cases/writers/PushMultiWriter.d
@@ -20,6 +20,9 @@ module dmqtest.cases.writers.PushMultiWriter;
 
 import dmqtest.cases.writers.model.IWriter;
 
+import ocean.transition;
+
+
 class PushMultiWriter : IWriter
 {
     /***************************************************************************

--- a/src/dmqtest/cases/writers/PushWriter.d
+++ b/src/dmqtest/cases/writers/PushWriter.d
@@ -20,6 +20,9 @@ module dmqtest.cases.writers.PushWriter;
 
 import dmqtest.cases.writers.model.IWriter;
 
+import ocean.transition;
+
+
 class PushWriter : IWriter
 {
     /***************************************************************************


### PR DESCRIPTION
I have no mean of testing this since I require Swarm v5.x.x to test, but updating DMQ proto is a bit too involved. Any ETA on it @david-eckardt-sociomantic ?
As soon as v14.x.x is compatible with Swarm v5.x.x I'll clean up any remaining issues with upstream compatibility.