### PR TITLE
Convert assert -> verify

### DIFF
--- a/src/dmqproto/client/UsageExamples.d
+++ b/src/dmqproto/client/UsageExamples.d
@@ -82,7 +82,7 @@ version ( UnitTest )
         // made.)
         private void connNotifier ( DmqClient.Neo.ConnNotification info )
         {
-            with ( info.Active ) switch ( info.active )
+            with ( info.Active ) final switch ( info.active )
             {
                 case connected:
                     Stdout.formatln("Connected to {}:{}",
@@ -97,8 +97,7 @@ version ( UnitTest )
                         info.error_while_connecting.node_addr.port);
                     break;
 
-                default:
-                    assert(false);
+                mixin(typeof(info).handleInvalidCases);
             }
         }
     }
@@ -148,7 +147,7 @@ unittest
             // represents one possible notification. `info.active` denotes
             // the type of the current notification. Some notifications
             // have fields containing more information:
-            with ( info.Active ) switch ( info.active )
+            with ( info.Active ) final switch ( info.active )
             {
                 case success:
                     Stdout.formatln("The request succeeded!");
@@ -178,7 +177,7 @@ unittest
                     break;
 
                 case unsupported:
-                    switch ( info.unsupported.type )
+                    final switch ( info.unsupported.type )
                     {
                         case info.unsupported.type.RequestNotSupported:
                             Stdout.formatln(
@@ -192,11 +191,11 @@ unittest
                                 info.unsupported.node_addr.address_bytes,
                                 info.unsupported.node_addr.port);
                             break;
-                        default: assert(false);
+                        version (D_Version2) {} else default: assert(false);
                     }
                     break;
 
-                default: assert(false);
+                mixin(typeof(info).handleInvalidCases);
             }
         }
     }
@@ -285,7 +284,7 @@ unittest
             // represents one possible notification. `info.active` denotes
             // the type of the current notification. Some notifications
             // have fields containing more information:
-            with ( info.Active ) switch ( info.active )
+            with ( info.Active ) final switch ( info.active )
             {
                 case received:
                     Stdout.formatln("'{}' received from channel '{}'",
@@ -323,7 +322,7 @@ unittest
                     break;
 
                 case unsupported:
-                    switch ( info.unsupported.type )
+                    final switch ( info.unsupported.type )
                     {
                         case info.unsupported.type.RequestNotSupported:
                             Stdout.formatln(
@@ -337,11 +336,11 @@ unittest
                                 info.unsupported.node_addr.address_bytes,
                                 info.unsupported.node_addr.port);
                             break;
-                        default: assert(false);
+                        version (D_Version2) {} else default: assert(false);
                     }
                     break;
 
-                default: assert(false);
+                mixin(typeof(info).handleInvalidCases);
             }
         }
 

--- a/src/dmqproto/client/internal/SharedResources.d
+++ b/src/dmqproto/client/internal/SharedResources.d
@@ -13,6 +13,7 @@
 module dmqproto.client.internal.SharedResources;
 
 import ocean.transition;
+import ocean.core.Verify;
 
 /// ditto
 public final class SharedResources
@@ -50,7 +51,7 @@ public final class SharedResources
     public static typeof(this) fromObject ( Object obj )
     {
         auto shared_resources = downcast!(typeof(this))(obj);
-        assert(shared_resources !is null);
+        verify(shared_resources !is null);
         return shared_resources;
     }
 

--- a/src/dmqproto/client/legacy/internal/RequestSetup.d
+++ b/src/dmqproto/client/legacy/internal/RequestSetup.d
@@ -41,6 +41,7 @@ import ocean.transition;
 public template IODelegate ( istring name )
 {
     import ocean.transition;
+    import ocean.core.Verify;
     import ocean.core.TypeConvert : downcast;
 
     mixin TypeofThis;
@@ -94,7 +95,7 @@ public template IODelegate ( istring name )
     private void setup_io_item ( IRequestParams params )
     {
         auto params_ = downcast!(RequestParams)(params);
-        assert(params_);
+        verify(params_ !is null);
 
         params_.io_item = this.io_item;
     }
@@ -196,7 +197,7 @@ public template IODelegate2 ( istring name )
     private void setup_io_item2 ( IRequestParams params )
     {
         auto params_ = downcast!(RequestParams)(params);
-        assert(params_);
+        verify(params_ !is null);
 
         params_.io_item2 = this.io_item2;
     }
@@ -242,6 +243,7 @@ public template IODelegate2 ( istring name )
 public template Channels ( )
 {
     import ocean.core.TypeConvert : downcast;
+    import ocean.core.Verify;
     import ocean.transition;
 
     mixin TypeofThis;
@@ -268,12 +270,9 @@ public template Channels ( )
     ***************************************************************************/
 
     public This* channels ( Const!(char[])[] channels )
-    in
     {
-        assert(channels.length, "multi-channel request: empty list of channels");
-    }
-    body
-    {
+        verify(!!channels.length, "multi-channel request: empty list of channels");
+
         this.channel_names = channels;
         version (D_Version2)
             return &this;
@@ -295,7 +294,7 @@ public template Channels ( )
     private void setup_channel_names ( IRequestParams params )
     {
         auto params_ = downcast!(RequestParams)(params);
-        assert(params_);
+        verify(params_ !is null);
 
         params_.channels = this.channel_names;
     }

--- a/src/dmqproto/client/legacy/internal/connection/DmqNodeConnectionPool.d
+++ b/src/dmqproto/client/legacy/internal/connection/DmqNodeConnectionPool.d
@@ -189,7 +189,7 @@ public class DmqNodeConnectionPool : NodeConnectionPool
              * another node.
              */
 
-            switch (this.reregistrator.registerNext(params))
+            final switch (this.reregistrator.registerNext(params))
             {
                 case RegisterNextResult.Reregistered,
                      RegisterNextResult.NoMoreNodes:
@@ -208,7 +208,7 @@ public class DmqNodeConnectionPool : NodeConnectionPool
                     super.queueRequest(params);
                     break;
 
-                default:
+                version (D_Version2) {} else default:
                     assert(false, "invalid RegisterNextResult");
             }
         }

--- a/src/dmqproto/client/legacy/internal/connection/DmqNodeConnectionPool.d
+++ b/src/dmqproto/client/legacy/internal/connection/DmqNodeConnectionPool.d
@@ -50,6 +50,7 @@ import dmqproto.client.legacy.internal.request.model.IRequest;
 import ocean.core.TypeConvert : downcast;
 
 import ocean.transition;
+import ocean.core.Verify;
 
 /*******************************************************************************
 
@@ -175,7 +176,7 @@ public class DmqNodeConnectionPool : NodeConnectionPool
     override protected void queueRequest ( IRequestParams iparams )
     {
         auto params = downcast!(RequestParams)(iparams);
-        assert(params);
+        verify(params !is null);
 
         if (params.force_assign)
         {
@@ -230,7 +231,7 @@ public class DmqNodeConnectionPool : NodeConnectionPool
         super.notifyRequestQueueOverflow(iparams); // Finished notification
 
         auto params = downcast!(RequestParams)(iparams);
-        assert(params);
+        verify(params !is null);
 
         if ( params.force_assign )
         {

--- a/src/dmqproto/client/legacy/internal/connection/DmqRequestConnection.d
+++ b/src/dmqproto/client/legacy/internal/connection/DmqRequestConnection.d
@@ -649,7 +649,7 @@ public class DmqRequestConnection :
         {
             auto dmq_params = cast(RequestParams)this.params;
 
-            with ( RegisterNextResult ) switch ( this.reregistrator.
+            with ( RegisterNextResult ) final switch ( this.reregistrator.
                 registerNext(dmq_params) )
             {
                 case MultipleNodeQuery: break;
@@ -676,7 +676,7 @@ public class DmqRequestConnection :
                         this.conn_pool.port, this.object_pool_index,
                         this.exception.toString());
                     break;
-                default:
+                version (D_Version2) {} else default:
                     assert(false, "unknown registerNext response");
             }
         }

--- a/src/dmqproto/client/legacy/internal/connection/DmqRequestConnection.d
+++ b/src/dmqproto/client/legacy/internal/connection/DmqRequestConnection.d
@@ -65,6 +65,7 @@ import dmqproto.client.legacy.internal.request.PushMultiRequest;
 debug ( SwarmClient ) import ocean.io.Stdout;
 
 import ocean.transition;
+import ocean.core.Verify;
 
 /*******************************************************************************
 
@@ -483,7 +484,7 @@ public class DmqRequestConnection :
 
     override protected void handleNone ( )
     {
-        assert(false, "Handling command with code None");
+        verify(false, "Handling command with code None");
     }
 
 

--- a/src/dmqproto/client/legacy/internal/registry/DmqNodeRegistry.d
+++ b/src/dmqproto/client/legacy/internal/registry/DmqNodeRegistry.d
@@ -379,7 +379,7 @@ public class DmqNodeRegistry : NodeRegistry, IDmqNodeRegistry, IReregistrator
 
     static private bool allNodesCommand ( uint command )
     {
-        with ( DmqConst.Command.E ) switch ( command )
+        with ( DmqConst.Command.E ) final switch ( command )
         {
             // Commands over all nodes
             case GetChannels:
@@ -398,7 +398,7 @@ public class DmqNodeRegistry : NodeRegistry, IDmqNodeRegistry, IReregistrator
             case Pop:
                 return false;
 
-            default:
+            version (D_Version2) {} else default:
                 assert(false, typeof(this).stringof ~ ".allNodesCommand: invalid request");
         }
     }

--- a/src/dmqproto/client/legacy/internal/registry/DmqNodeRegistry.d
+++ b/src/dmqproto/client/legacy/internal/registry/DmqNodeRegistry.d
@@ -48,6 +48,7 @@ import ocean.core.TypeConvert : castFrom, downcast;
 debug ( SwarmClient ) import ocean.io.Stdout;
 
 import ocean.transition;
+import ocean.core.Verify;
 
 /******************************************************************************
 
@@ -110,12 +111,9 @@ public class DmqNodeRegistry : NodeRegistry, IDmqNodeRegistry, IReregistrator
     public this ( EpollSelectDispatcher epoll, ClientSettings settings,
         IRequestOverflow request_overflow,
         INodeConnectionPoolErrorReporter error_reporter )
-    in
     {
-        assert(epoll !is null, typeof(this).stringof ~ ".ctor: epoll must be non-null");
-    }
-    body
-    {
+        verify(epoll !is null, typeof(this).stringof ~ ".ctor: epoll must be non-null");
+
         super(epoll, settings, request_overflow,
             new NodeSet(this.expected_nodes), error_reporter);
 
@@ -253,7 +251,7 @@ public class DmqNodeRegistry : NodeRegistry, IDmqNodeRegistry, IReregistrator
                 break;
 
             default:
-                assert(false, "invalid command");
+                verify(false, "invalid command");
         }
 
         return this.currentNode(dmq_params);
@@ -274,12 +272,9 @@ public class DmqNodeRegistry : NodeRegistry, IDmqNodeRegistry, IReregistrator
     ***************************************************************************/
 
     private uint nextPool ( ref uint index )
-    in
     {
-        assert(index < super.nodes.list.length, typeof (this).stringof ~ ".getPool - index out of range");
-    }
-    body
-    {
+        verify(index < super.nodes.list.length, typeof (this).stringof ~ ".getPool - index out of range");
+
         auto pool = index;
         if ( ++index >= super.nodes.list.length )
         {
@@ -330,10 +325,6 @@ public class DmqNodeRegistry : NodeRegistry, IDmqNodeRegistry, IReregistrator
     ***************************************************************************/
 
     private DmqNodeConnectionPool getPoolWithLowestQueueUsage ( uint start )
-    in
-    {
-        assert(start < this.nodes.list.length);
-    }
     out (node)
     {
         assert(node);
@@ -344,6 +335,8 @@ public class DmqNodeRegistry : NodeRegistry, IDmqNodeRegistry, IReregistrator
     }
     body
     {
+        verify(start < this.nodes.list.length);
+
         auto pos = start;
         auto selected_node = this.nodes.list[this.nextPool(pos)];
         auto selected_queued = selected_node.queued_bytes + selected_node.overflowed_bytes;

--- a/src/dmqproto/client/legacy/internal/request/PopRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/PopRequest.d
@@ -30,6 +30,7 @@ import dmqproto.client.legacy.internal.request.notifier.RequestNotification;
 import dmqproto.client.legacy.internal.connection.model.IReregistrator;
 
 import ocean.transition;
+import ocean.core.Verify;
 
 
 /*******************************************************************************
@@ -104,7 +105,8 @@ public scope class PopRequest : IChannelRequest
             {
                 case Reregistered: break;
                 case MultipleNodeQuery:
-                    assert(false, "pop: is not multiple node");
+                    verify(false, "pop: is not multiple node");
+                    assert(false);
                 case NoMoreNodes:
                     this.finished(value); break;
                 version (D_Version2) {} else default:

--- a/src/dmqproto/client/legacy/internal/request/PopRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/PopRequest.d
@@ -99,7 +99,7 @@ public scope class PopRequest : IChannelRequest
         {
             this.params.force_assign = true;
 
-            with ( RegisterNextResult ) switch ( this.resources.reregistrator.
+            with ( RegisterNextResult ) final switch ( this.resources.reregistrator.
                 registerNext(this.params) )
             {
                 case Reregistered: break;
@@ -107,7 +107,7 @@ public scope class PopRequest : IChannelRequest
                     assert(false, "pop: is not multiple node");
                 case NoMoreNodes:
                     this.finished(value); break;
-                default:
+                version (D_Version2) {} else default:
                     assert(false, "pop: unknown registerNext response");
             }
         }

--- a/src/dmqproto/client/legacy/internal/request/PushMultiRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/PushMultiRequest.d
@@ -113,7 +113,7 @@ public scope class PushMultiRequest : IMultiChannelRequest
 
     override protected void statusActionFatal ( )
     {
-        with ( RegisterNextResult ) switch ( this.resources.reregistrator.
+        with ( RegisterNextResult ) final switch ( this.resources.reregistrator.
             registerNext(this.params) )
         {
             case Reregistered: break;
@@ -123,7 +123,7 @@ public scope class PushMultiRequest : IMultiChannelRequest
                 break;
             case MultipleNodeQuery:
                 assert(false, "pushMulti: request is not multiple node");
-            default:
+            version (D_Version2) {} else default:
                 assert(false, "pushMulti: unknown registerNext response");
         }
     }

--- a/src/dmqproto/client/legacy/internal/request/PushMultiRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/PushMultiRequest.d
@@ -29,6 +29,7 @@ import swarm.client.ClientExceptions;
 import dmqproto.client.legacy.internal.connection.model.IReregistrator;
 
 import ocean.core.Enforce;
+import ocean.core.Verify;
 
 
 
@@ -122,7 +123,8 @@ public scope class PushMultiRequest : IMultiChannelRequest
                     (__FILE__, __LINE__));
                 break;
             case MultipleNodeQuery:
-                assert(false, "pushMulti: request is not multiple node");
+                verify(false, "pushMulti: request is not multiple node");
+                assert(false);
             version (D_Version2) {} else default:
                 assert(false, "pushMulti: unknown registerNext response");
         }

--- a/src/dmqproto/client/legacy/internal/request/PushRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/PushRequest.d
@@ -31,6 +31,7 @@ import dmqproto.client.legacy.internal.connection.model.IReregistrator;
 import swarm.client.ClientExceptions;
 
 import ocean.core.Enforce;
+import ocean.core.Verify;
 
 
 
@@ -149,7 +150,8 @@ public scope class PushRequest : IChannelRequest
                     (__FILE__, __LINE__));
                 break;
             case MultipleNodeQuery:
-                assert(false, "push: is not multiple node");
+                verify(false, "push: is not multiple node");
+                assert(false);
             version (D_Version2) {} else default:
                 assert(false, "push: unknown registerNext response");
         }

--- a/src/dmqproto/client/legacy/internal/request/PushRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/PushRequest.d
@@ -140,7 +140,7 @@ public scope class PushRequest : IChannelRequest
 
     private void tryNextNode ( )
     {
-        with ( RegisterNextResult ) switch ( this.resources.reregistrator.
+        with ( RegisterNextResult ) final switch ( this.resources.reregistrator.
             registerNext(this.params) )
         {
             case Reregistered: break;
@@ -150,7 +150,7 @@ public scope class PushRequest : IChannelRequest
                 break;
             case MultipleNodeQuery:
                 assert(false, "push: is not multiple node");
-            default:
+            version (D_Version2) {} else default:
                 assert(false, "push: unknown registerNext response");
         }
     }

--- a/src/dmqproto/client/legacy/internal/request/notifier/RequestNotification.d
+++ b/src/dmqproto/client/legacy/internal/request/notifier/RequestNotification.d
@@ -26,6 +26,8 @@ import swarm.Const;
 
 import dmqproto.client.legacy.DmqConst;
 
+import ocean.core.Verify;
+
 
 
 /*******************************************************************************
@@ -48,7 +50,7 @@ public scope class RequestNotification : IRequestNotification
 
     public this ( ICommandCodes.Value command, Context context )
     {
-        assert(command in DmqConst.Command());
+        verify(!!(command in DmqConst.Command()));
 
         super(DmqConst.Command(), DmqConst.Status(), command, context);
     }

--- a/src/dmqproto/client/mixins/NeoSupport.d
+++ b/src/dmqproto/client/mixins/NeoSupport.d
@@ -436,7 +436,7 @@ template NeoSupport ( )
                 if ( user_notifier )
                     user_notifier(info, args);
 
-                with ( info.Active ) switch ( info.active )
+                with ( info.Active ) final switch ( info.active )
                 {
                     case success:
                         state = state.Succeeded;
@@ -455,7 +455,7 @@ template NeoSupport ( )
                     case unsupported:
                         break;
 
-                    default: assert(false);
+                    mixin(typeof(info).handleInvalidCases);
                 }
             }
 
@@ -536,7 +536,7 @@ template NeoSupport ( )
                 if ( user_notifier )
                     user_notifier(info, args);
 
-                with ( info.Active ) switch ( info.active )
+                with ( info.Active ) final switch ( info.active )
                 {
                     case received:
                         value.copy(info.received.value);
@@ -564,7 +564,7 @@ template NeoSupport ( )
                     case channel_has_subscribers:
                         break;
 
-                    default: assert(false);
+                    mixin(typeof(info).handleInvalidCases);
                 }
             }
 

--- a/src/dmqproto/client/request/internal/Consume.d
+++ b/src/dmqproto/client/request/internal/Consume.d
@@ -615,7 +615,7 @@ private scope class ConsumeHandler
                     Message(MessageType_v3.ChannelRemoved)
                 );
 
-                switch (msg.type)
+                final switch (msg.type)
                 {
                     case MessageType_v3.Records:
                         Const!(void)[] received_record_batch;
@@ -633,7 +633,7 @@ private scope class ConsumeHandler
                         // TODO
                         break;
 
-                    default:
+                    version (D_Version2) {} else default:
                         assert(false);
                 }
             }
@@ -689,7 +689,7 @@ private scope class ConsumeHandler
                     Signal(FiberSignal.StopController)
                 );
 
-                switch (event.signal.code)
+                final switch (event.signal.code)
                 {
                     case ControllerSignal.Resume:
                         this.record_stream.resume();
@@ -709,7 +709,7 @@ private scope class ConsumeHandler
                     case FiberSignal.StopController:
                         return;
 
-                    default:
+                    version (D_Version2) {} else default:
                         assert(false);
                 }
             }

--- a/src/dmqproto/client/request/internal/Consume.d
+++ b/src/dmqproto/client/request/internal/Consume.d
@@ -13,6 +13,7 @@
 module dmqproto.client.request.internal.Consume;
 
 import ocean.transition;
+import ocean.core.Verify;
 
 import swarm.neo.client.RequestOnConn;
 
@@ -299,9 +300,9 @@ private scope class ConsumeHandler
 
         this.request_event_dispatcher.eventLoop(this.conn);
 
-        with (record_stream.fiber)  assert(state == state.TERM);
-        with (reader.fiber)         assert(state == state.TERM);
-        with (controller.fiber)     assert(state == state.TERM);
+        with (record_stream.fiber)  verify(state == state.TERM);
+        with (reader.fiber)         verify(state == state.TERM);
+        with (controller.fiber)     verify(state == state.TERM);
     }
 
     /***************************************************************************

--- a/src/dmqproto/client/request/internal/Push.d
+++ b/src/dmqproto/client/request/internal/Push.d
@@ -19,6 +19,7 @@ module dmqproto.client.request.internal.Push;
 *******************************************************************************/
 
 import ocean.transition;
+import ocean.core.Verify;
 import ocean.util.log.Logger;
 
 /*******************************************************************************
@@ -124,7 +125,7 @@ public struct Push
         {
             try
             {
-                assert(context.user_params.args.channels.length <= 255);
+                verify(context.user_params.args.channels.length <= 255);
                 auto num_channels =
                     cast(ubyte)context.user_params.args.channels.length;
 

--- a/src/dmqproto/node/neo/request/Consume.d
+++ b/src/dmqproto/node/neo/request/Consume.d
@@ -28,6 +28,7 @@ public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
 
     import swarm.util.RecordBatcher;
 
+    import ocean.core.Verify;
     import ocean.transition;
 
     /***************************************************************************
@@ -244,7 +245,7 @@ public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
                     return;
 
                 default:
-                    assert(false, "Consume: Unexpected fiber resume code");
+                    verify(false, "Consume: Unexpected fiber resume code");
             }
         }
     }

--- a/src/dmqproto/node/neo/request/core/IRequestHandlerRequest.d
+++ b/src/dmqproto/node/neo/request/core/IRequestHandlerRequest.d
@@ -20,6 +20,7 @@ abstract class IRequestHandlerRequest: IRequestHandler
 {
     import swarm.neo.node.RequestOnConn;
     import dmqproto.node.neo.request.core.IRequestResources;
+    import ocean.core.Verify;
     import ocean.transition;
 
     /// Request-on-conn of this request handler.
@@ -52,7 +53,7 @@ abstract class IRequestHandlerRequest: IRequestHandler
     {
         this.connection = connection;
         this.resources = cast(IRequestResources)resources_object;
-        assert(this.resources !is null);
+        verify(this.resources !is null);
     }
 
     /***************************************************************************


### PR DESCRIPTION
Fixes #40.

I left the `assert`s in the `dmqtest`, `fakedmq` and `turtle` packages as they are not used in production. 