### PR TITLE
Disable Nagle's algorithm in client and remove explicit flushing

### DIFF
--- a/src/dmqproto/client/mixins/NeoSupport.d
+++ b/src/dmqproto/client/mixins/NeoSupport.d
@@ -625,6 +625,7 @@ template NeoSupport ( )
     {
         this.neo = new Neo(config, Neo.Settings(conn_notifier, new SharedResources));
         this.blocking = new TaskBlocking;
+        this.neo.enableSocketNoDelay();
     }
 
 
@@ -651,5 +652,6 @@ template NeoSupport ( )
     {
         this.neo = new Neo(auth_name, auth_key, Neo.Settings(conn_notifier, new SharedResources));
         this.blocking = new TaskBlocking;
+        this.neo.enableSocketNoDelay();
     }
 }

--- a/src/dmqproto/client/request/internal/Consume.d
+++ b/src/dmqproto/client/request/internal/Consume.d
@@ -479,8 +479,6 @@ private scope class ConsumeHandler
                         payload.addCopy(MessageType_v3.Continue);
                     }
                 );
-
-                this.outer.conn.flush();
             }
 
             this.outer.request_event_dispatcher.signal(this.outer.conn,
@@ -703,7 +701,6 @@ private scope class ConsumeHandler
                                 payload.addCopy(MessageType_v3.Stop);
                             }
                         );
-                        this.outer.conn.flush();
                         break;
 
                     case FiberSignal.StopController:

--- a/src/dmqproto/client/request/internal/Pop.d
+++ b/src/dmqproto/client/request/internal/Pop.d
@@ -142,7 +142,6 @@ public struct Pop
                         payload.addArray(context.user_params.args.channel);
                     }
                 );
-                conn.flush();
 
                 auto supported = conn.receiveValue!(SupportedStatus)();
                 if ( Pop.handleSupportedCodes(supported, context,

--- a/src/dmqproto/client/request/internal/Push.d
+++ b/src/dmqproto/client/request/internal/Push.d
@@ -140,7 +140,6 @@ public struct Push
                         payload.addArray(context.user_params.args.value);
                     }
                 );
-                conn.flush();
 
                 auto supported = conn.receiveValue!(SupportedStatus)();
                 if ( Push.handleSupportedCodes(supported, context,

--- a/src/dmqproto/node/neo/request/Consume.d
+++ b/src/dmqproto/node/neo/request/Consume.d
@@ -326,7 +326,6 @@ public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
         switch (event.active)
         {
             case event.active.sent:
-                this.ed.flush();
                 // Records sent: Wait for Consume/Stop feedback, acknowledge
                 // Stop and return true for Continue or false for Stop.
                 switch (this.ed.receiveValue!(MessageType_v3)())
@@ -368,7 +367,6 @@ public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
                 payload.addCopy(MessageType_v3.Stopped);
             }
         );
-        this.ed.flush();
     }
 
     /***************************************************************************

--- a/src/dmqproto/node/neo/request/Pop.d
+++ b/src/dmqproto/node/neo/request/Pop.d
@@ -86,8 +86,6 @@ public abstract class PopProtocol_v0: IRequestHandlerRequest
                 }
             );
         }
-
-        ed.flush();
     }
 
     /***************************************************************************

--- a/src/dmqproto/node/neo/request/Push.d
+++ b/src/dmqproto/node/neo/request/Push.d
@@ -82,8 +82,6 @@ public abstract class PushProtocol_v2: IRequestHandlerRequest
                 }
             );
         }
-
-        ed.flush();
     }
 
     /***************************************************************************


### PR DESCRIPTION
As per dmqproto#48, TCP_CORK based flushing doesn't work in general,
however it's also no longer necessary, since we're doing explicit
buffering via record batching in Consume, and for all the control
messages, we're anyway flushing as soon as we send it. This makes
TCP_NODELAY fit for this purpose: as soon as we write the control
message it will be sent, and the batch will be sent as soon as sendmsg
returns, so there's no need for explicit flushing.

Fixes #48