### PR TITLE
Pass the request resources to abstract methods in node requests

### DIFF
--- a/src/dmqproto/node/neo/request/Consume.d
+++ b/src/dmqproto/node/neo/request/Consume.d
@@ -154,7 +154,7 @@ public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
         cstring subscriber_name;
         this.parser.parseBody(msg_payload, channel_name, subscriber_name);
 
-        if ( !this.prepareChannel(channel_name, subscriber_name) )
+        if ( !this.prepareChannel(resources, channel_name, subscriber_name) )
         {
             this.ed.send(
                 ( ed.Payload payload )
@@ -398,6 +398,7 @@ public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
         channel of the given name.
 
         Params:
+            resources = request resources
             channel_name = channel to consume from
             subscriber_name = the identifying name of the subscriber
 
@@ -406,7 +407,8 @@ public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
 
     ***************************************************************************/
 
-    abstract protected bool prepareChannel ( cstring channel_name,
+    abstract protected bool prepareChannel ( IRequestResources resources,
+                                             cstring channel_name,
                                              cstring subscriber_name );
 
     /***************************************************************************

--- a/src/dmqproto/node/neo/request/Pop.d
+++ b/src/dmqproto/node/neo/request/Pop.d
@@ -53,7 +53,7 @@ public abstract class PopProtocol_v0: IRequestHandlerRequest
 
         bool subscribed;
 
-        if (this.prepareChannel(channel_name, subscribed))
+        if (this.prepareChannel(resources, channel_name, subscribed))
         {
             auto value = resources.getVoidBuffer();
             if ( this.getNextValue(*value) )
@@ -96,6 +96,7 @@ public abstract class PopProtocol_v0: IRequestHandlerRequest
         Performs any logic needed to pop from the channel of the given name.
 
         Params:
+            resources = request resources
             channel_name = channel to pop from
             subscribed = `true` if the return value is `false` because the
                 channel has subscribers so it is not possible to pop from it
@@ -105,8 +106,8 @@ public abstract class PopProtocol_v0: IRequestHandlerRequest
 
     ***************************************************************************/
 
-    abstract protected bool prepareChannel ( cstring channel_name,
-        out bool subscribed );
+    abstract protected bool prepareChannel ( IRequestResources resources,
+        cstring channel_name, out bool subscribed );
 
     /***************************************************************************
 

--- a/src/dmqproto/node/neo/request/Push.d
+++ b/src/dmqproto/node/neo/request/Push.d
@@ -36,7 +36,7 @@ public abstract class PushProtocol_v2: IRequestHandlerRequest
 
         Params:
             connection = connection to client
-            resources = request resources acquirer
+            resources = request resources
             msg_payload = initial message read from client to begin the request
                 (the request code and version are assumed to be extracted)
 
@@ -61,11 +61,11 @@ public abstract class PushProtocol_v2: IRequestHandlerRequest
         Const!(void)[] value;
         parser.parseBody(msg_payload, value);
 
-        if ( this.prepareChannels(channel_names.array) )
+        if ( this.prepareChannels(resources, channel_names.array) )
         {
             foreach ( channel_name; channel_names.array )
             {
-                this.pushToStorage(channel_name, value);
+                this.pushToStorage(resources, channel_name, value);
             }
 
             ed.send(
@@ -92,6 +92,7 @@ public abstract class PushProtocol_v2: IRequestHandlerRequest
         written to.
 
         Params:
+            resources = request resources acquirer
             channel_names = list of channel names to check
 
         Returns:
@@ -100,13 +101,15 @@ public abstract class PushProtocol_v2: IRequestHandlerRequest
 
     ***************************************************************************/
 
-    abstract protected bool prepareChannels ( in cstring[] channel_names );
+    abstract protected bool prepareChannels ( IRequestResources resources,
+        in cstring[] channel_names );
 
     /***************************************************************************
 
         Push a record to the specified storage channel.
 
         Params:
+            resources = request resources
             channel_name = channel to push to
             value = record value to push
 
@@ -115,6 +118,6 @@ public abstract class PushProtocol_v2: IRequestHandlerRequest
 
     ***************************************************************************/
 
-    abstract protected bool pushToStorage ( cstring channel_name,
-        in void[] value );
+    abstract protected bool pushToStorage ( IRequestResources resources,
+        cstring channel_name, in void[] value );
 }

--- a/src/fakedmq/neo/request/Consume.d
+++ b/src/fakedmq/neo/request/Consume.d
@@ -32,6 +32,8 @@ import ocean.transition;
 
 class ConsumeImpl_v3 : ConsumeProtocol_v3, DmqListener
 {
+    import dmqproto.node.neo.request.core.IRequestResources;
+
     /***************************************************************************
 
         Remember consumed channel
@@ -46,6 +48,7 @@ class ConsumeImpl_v3 : ConsumeProtocol_v3, DmqListener
         given name.
 
         Params:
+            resources = request resources
             channel_name = channel to subscribe to
             subscriber_name = subscriber name (v2 only)
 
@@ -54,8 +57,8 @@ class ConsumeImpl_v3 : ConsumeProtocol_v3, DmqListener
 
     ***************************************************************************/
 
-    override protected bool prepareChannel ( cstring channel_name,
-        cstring subscriber_name )
+    override protected bool prepareChannel ( IRequestResources resources,
+        cstring channel_name, cstring subscriber_name )
     {
         this.queue = global_storage.getCreate(channel_name)
             .subscribe(subscriber_name);

--- a/src/fakedmq/neo/request/Pop.d
+++ b/src/fakedmq/neo/request/Pop.d
@@ -31,6 +31,7 @@ import ocean.transition;
 class PopImpl_v0 : PopProtocol_v0
 {
     import fakedmq.Storage;
+    import dmqproto.node.neo.request.core.IRequestResources;
 
     /***************************************************************************
 
@@ -45,6 +46,7 @@ class PopImpl_v0 : PopProtocol_v0
         Performs any logic needed to pop from the channel of the given name.
 
         Params:
+            resources = request resources
             channel_name = channel to pop from
             subscribed = `true` if the return value is `false` because the
                 channel has subscribers so it is not possible to pop from it
@@ -54,8 +56,8 @@ class PopImpl_v0 : PopProtocol_v0
 
     ***************************************************************************/
 
-    override protected bool prepareChannel ( cstring channel_name,
-        out bool subscribed )
+    override protected bool prepareChannel ( IRequestResources resources,
+        cstring channel_name, out bool subscribed )
     {
         this.queue = global_storage.getCreate(channel_name).queue_unless_subscribed;
         subscribed = this.queue is null;

--- a/src/fakedmq/neo/request/Push.d
+++ b/src/fakedmq/neo/request/Push.d
@@ -31,6 +31,7 @@ import ocean.transition;
 class PushImpl_v2 : PushProtocol_v2
 {
     import fakedmq.Storage;
+    import dmqproto.node.neo.request.core.IRequestResources;
 
     /***************************************************************************
 
@@ -38,6 +39,7 @@ class PushImpl_v2 : PushProtocol_v2
         written to.
 
         Params:
+            resources = request resources
             channel_names = list of channel names to check
 
         Returns:
@@ -46,7 +48,8 @@ class PushImpl_v2 : PushProtocol_v2
 
     ***************************************************************************/
 
-    override protected bool prepareChannels ( in cstring[] channel_names )
+    override protected bool prepareChannels ( IRequestResources resources,
+        in cstring[] channel_names )
     {
         foreach ( channel; channel_names )
         {
@@ -62,7 +65,8 @@ class PushImpl_v2 : PushProtocol_v2
         Push a record to the specified storage channel.
 
         Params:
-            channel_name = channel to push to
+            resources = request resources
+                channel_name = channel to push to
             value = record value to push
 
         Returns:
@@ -70,8 +74,8 @@ class PushImpl_v2 : PushProtocol_v2
 
     ***************************************************************************/
 
-    override protected bool pushToStorage ( cstring channel_name,
-        in void[] value )
+    override protected bool pushToStorage ( IRequestResources resources,
+        cstring channel_name, in void[] value )
     {
         global_storage.getCreate(channel_name).push(value);
 


### PR DESCRIPTION
The dmqnode implementations of these methods need them.