### PR TITLE
Fix request version numbers to account for hidden protocol change

### DIFF
--- a/src/dmqproto/client/request/internal/Consume.d
+++ b/src/dmqproto/client/request/internal/Consume.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    Client DMQ Consume v3 request handler.
+    Client DMQ Consume v4 request handler.
 
     Copyright:
         Copyright (c) 2017 sociomantic labs GmbH. All rights reserved.
@@ -19,7 +19,7 @@ import swarm.neo.client.RequestOnConn;
 
 /*******************************************************************************
 
-    Consume v3 request implementation.
+    Consume v4 request implementation.
 
     Note that request structs act simply as namespaces for the collection of
     symbols required to implement a request. They are never instantiated and
@@ -99,7 +99,7 @@ public struct Consume
 
     ***************************************************************************/
 
-    mixin RequestCore!(RequestType.AllNodes, RequestCode.Consume, 3, Args,
+    mixin RequestCore!(RequestType.AllNodes, RequestCode.Consume, 4, Args,
         SharedWorking, Notification);
 
     /***************************************************************************

--- a/src/dmqproto/client/request/internal/Consume.d
+++ b/src/dmqproto/client/request/internal/Consume.d
@@ -477,7 +477,7 @@ private scope class ConsumeHandler
                     this.fiber,
                     (conn.Payload payload)
                     {
-                        payload.addCopy(MessageType_v3.Continue);
+                        payload.addCopy(MessageType.Continue);
                     }
                 );
             }
@@ -609,14 +609,14 @@ private scope class ConsumeHandler
             {
                 auto msg = this.outer.request_event_dispatcher.receive(
                     this.fiber,
-                    Message(MessageType_v3.Records),
-                    Message(MessageType_v3.Stopped),
-                    Message(MessageType_v3.ChannelRemoved)
+                    Message(MessageType.Records),
+                    Message(MessageType.Stopped),
+                    Message(MessageType.ChannelRemoved)
                 );
 
                 final switch (msg.type)
                 {
-                    case MessageType_v3.Records:
+                    case MessageType.Records:
                         Const!(void)[] received_record_batch;
                         this.outer.conn.message_parser.parseBody(
                             msg.payload, received_record_batch
@@ -624,11 +624,11 @@ private scope class ConsumeHandler
                         this.record_stream.addRecords(received_record_batch);
                         break;
 
-                    case MessageType_v3.Stopped:
+                    case MessageType.Stopped:
                         this.record_stream.stop();
                         return;
 
-                    case MessageType_v3.ChannelRemoved:
+                    case MessageType.ChannelRemoved:
                         // TODO
                         break;
 
@@ -699,7 +699,7 @@ private scope class ConsumeHandler
                             this.fiber,
                             (conn.Payload payload)
                             {
-                                payload.addCopy(MessageType_v3.Stop);
+                                payload.addCopy(MessageType.Stop);
                             }
                         );
                         break;

--- a/src/dmqproto/client/request/internal/Pop.d
+++ b/src/dmqproto/client/request/internal/Pop.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    Client DMQ Pop v0 request handler.
+    Client DMQ Pop v1 request handler.
 
     Copyright:
         Copyright (c) 2016-2017 sociomantic labs GmbH. All rights reserved.
@@ -107,7 +107,7 @@ public struct Pop
 
     ***************************************************************************/
 
-    mixin RequestCore!(RequestType.RoundRobin, RequestCode.Pop, 0, Args,
+    mixin RequestCore!(RequestType.RoundRobin, RequestCode.Pop, 1, Args,
         SharedWorking, Notification);
 
     /***************************************************************************

--- a/src/dmqproto/client/request/internal/Push.d
+++ b/src/dmqproto/client/request/internal/Push.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    Client DMQ Push v2 request handler.
+    Client DMQ Push v3 request handler.
 
     Copyright:
         Copyright (c) 2016-2017 sociomantic labs GmbH. All rights reserved.
@@ -101,7 +101,7 @@ public struct Push
 
     ***************************************************************************/
 
-    mixin RequestCore!(RequestType.RoundRobin, RequestCode.Push, 2, Args,
+    mixin RequestCore!(RequestType.RoundRobin, RequestCode.Push, 3, Args,
         SharedWorking, Notification);
 
     /***************************************************************************

--- a/src/dmqproto/common/Consume.d
+++ b/src/dmqproto/common/Consume.d
@@ -34,28 +34,6 @@ public enum RequestStatusCode : StatusCode
     Error    // Internal node error occurred
 }
 
-/*******************************************************************************
-
-    Message type enum for Consume v1 and v2. Each message sent between the
-    client and the node as part of a Consume request is prepended by a type indicator.
-
-*******************************************************************************/
-
-public enum MessageType : ubyte
-{
-    None,       // Invalid, default value
-
-    // Message types sent from the client to the node:
-    Suspend,    // Sent when the client wants the node to stop sending records
-    Resume,     // Sent when the client wants the node to restart sending records
-    Stop,       // Sent when the client wants the node to cleanly end the request
-    ChannelRemoved, // Sent when the channel being consumed is removed
-
-    // Message types sent from the node to the client:
-    Ack,        // Sent by the node to acknowledge one of the above messages
-    Record      // Sent by the node when it sends a record value
-}
-
 /// Message type enum for Consume v3.
 public enum MessageType_v3 : ubyte
 {

--- a/src/dmqproto/common/Consume.d
+++ b/src/dmqproto/common/Consume.d
@@ -34,8 +34,8 @@ public enum RequestStatusCode : StatusCode
     Error    // Internal node error occurred
 }
 
-/// Message type enum for Consume v3.
-public enum MessageType_v3 : ubyte
+/// Message type enum.
+public enum MessageType : ubyte
 {
     None,            // Invalid, default value
 

--- a/src/dmqproto/node/neo/request/Consume.d
+++ b/src/dmqproto/node/neo/request/Consume.d
@@ -16,11 +16,11 @@ import dmqproto.node.neo.request.core.IRequestHandlerRequest;
 
 /*******************************************************************************
 
-    v3 Consume request protocol.
+    v4 Consume request protocol.
 
 *******************************************************************************/
 
-public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
+public abstract scope class ConsumeProtocol_v4: IRequestHandlerRequest
 {
     import swarm.neo.node.RequestOnConn;
     import dmqproto.node.neo.request.core.IRequestResources;

--- a/src/dmqproto/node/neo/request/Consume.d
+++ b/src/dmqproto/node/neo/request/Consume.d
@@ -193,7 +193,7 @@ public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
         this.ed.send(
             ( ed.Payload payload )
             {
-                payload.addCopy(MessageType_v3.ChannelRemoved);
+                payload.addCopy(MessageType.ChannelRemoved);
             }
         );
     }
@@ -309,7 +309,7 @@ public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
     {
         void fillInRecordsMessage ( ed.Payload payload )
         {
-            payload.addCopy(MessageType_v3.Records);
+            payload.addCopy(MessageType.Records);
             payload.addArray(*this.record_batch);
         }
 
@@ -329,12 +329,12 @@ public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
             case event.active.sent:
                 // Records sent: Wait for Consume/Stop feedback, acknowledge
                 // Stop and return true for Continue or false for Stop.
-                switch (this.ed.receiveValue!(MessageType_v3)())
+                switch (this.ed.receiveValue!(MessageType)())
                 {
-                    case MessageType_v3.Continue:
+                    case MessageType.Continue:
                         return true;
 
-                    case MessageType_v3.Stop:
+                    case MessageType.Stop:
                         this.sendStoppedMessage();
                         return false;
 
@@ -365,7 +365,7 @@ public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
         this.ed.send(
             (ed.Payload payload)
             {
-                payload.addCopy(MessageType_v3.Stopped);
+                payload.addCopy(MessageType.Stopped);
             }
         );
     }
@@ -373,7 +373,7 @@ public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
     /***************************************************************************
 
         Parses `msg_payload`, expecting the message type to be
-        `MessageType_v3.Stop`, and raises a protocol error if it is not so.
+        `MessageType.Stop`, and raises a protocol error if it is not so.
 
         Params:
             msg_payload = the payload of a received message
@@ -383,7 +383,7 @@ public abstract scope class ConsumeProtocol_v3: IRequestHandlerRequest
     private void verifyReceivedMessageIsStop ( in void[] msg_payload,
         istring file = __FILE__, int line = __LINE__ )
     {
-        MessageType_v3 msg_type;
+        MessageType msg_type;
         this.parser.parseBody(msg_payload, msg_type);
         if (msg_type != msg_type.Stop)
             throw this.ed.shutdownWithProtocolError(

--- a/src/dmqproto/node/neo/request/Pop.d
+++ b/src/dmqproto/node/neo/request/Pop.d
@@ -20,7 +20,7 @@ import dmqproto.node.neo.request.core.IRequestHandlerRequest;
 
 *******************************************************************************/
 
-public abstract class PopProtocol_v0: IRequestHandlerRequest
+public abstract class PopProtocol_v1: IRequestHandlerRequest
 {
     import dmqproto.common.Pop;
     import dmqproto.node.neo.request.core.IRequestResources;

--- a/src/dmqproto/node/neo/request/Push.d
+++ b/src/dmqproto/node/neo/request/Push.d
@@ -16,11 +16,11 @@ import dmqproto.node.neo.request.core.IRequestHandlerRequest;
 
 /*******************************************************************************
 
-    v2 Push request protocol.
+    v3 Push request protocol.
 
 *******************************************************************************/
 
-public abstract class PushProtocol_v2: IRequestHandlerRequest
+public abstract class PushProtocol_v3: IRequestHandlerRequest
 {
     import dmqproto.common.Push;
     import dmqproto.node.neo.request.core.IRequestResources;

--- a/src/fakedmq/neo/RequestHandlers.d
+++ b/src/fakedmq/neo/RequestHandlers.d
@@ -34,6 +34,6 @@ public ConnectionHandler.RequestMap request_handlers;
 static this ( )
 {
     request_handlers.add(Command(RequestCode.Consume, 3), "consume", ConsumeImpl_v3.classinfo);
-    request_handlers.add(Command(RequestCode.Push, 2), "push", PushImpl_v2.classinfo);
+    request_handlers.add(Command(RequestCode.Push, 3), "push", PushImpl_v3.classinfo);
     request_handlers.add(Command(RequestCode.Pop, 0), "pop", PopImpl_v0.classinfo);
 }

--- a/src/fakedmq/neo/RequestHandlers.d
+++ b/src/fakedmq/neo/RequestHandlers.d
@@ -35,5 +35,5 @@ static this ( )
 {
     request_handlers.add(Command(RequestCode.Consume, 4), "consume", ConsumeImpl_v4.classinfo);
     request_handlers.add(Command(RequestCode.Push, 3), "push", PushImpl_v3.classinfo);
-    request_handlers.add(Command(RequestCode.Pop, 0), "pop", PopImpl_v0.classinfo);
+    request_handlers.add(Command(RequestCode.Pop, 1), "pop", PopImpl_v1.classinfo);
 }

--- a/src/fakedmq/neo/RequestHandlers.d
+++ b/src/fakedmq/neo/RequestHandlers.d
@@ -33,7 +33,7 @@ public ConnectionHandler.RequestMap request_handlers;
 
 static this ( )
 {
-    request_handlers.add(Command(RequestCode.Consume, 3), "consume", ConsumeImpl_v3.classinfo);
+    request_handlers.add(Command(RequestCode.Consume, 4), "consume", ConsumeImpl_v4.classinfo);
     request_handlers.add(Command(RequestCode.Push, 3), "push", PushImpl_v3.classinfo);
     request_handlers.add(Command(RequestCode.Pop, 0), "pop", PopImpl_v0.classinfo);
 }

--- a/src/fakedmq/neo/request/Consume.d
+++ b/src/fakedmq/neo/request/Consume.d
@@ -26,11 +26,11 @@ import ocean.transition;
 
 /*******************************************************************************
 
-    Fake node implementation of the v3 Consume request protocol.
+    Fake node implementation of the v4 Consume request protocol.
 
 *******************************************************************************/
 
-class ConsumeImpl_v3 : ConsumeProtocol_v3, DmqListener
+class ConsumeImpl_v4 : ConsumeProtocol_v4, DmqListener
 {
     import dmqproto.node.neo.request.core.IRequestResources;
 

--- a/src/fakedmq/neo/request/Pop.d
+++ b/src/fakedmq/neo/request/Pop.d
@@ -24,11 +24,11 @@ import ocean.transition;
 
 /*******************************************************************************
 
-    Fake node implementation of the v0 Pop request protocol.
+    Fake node implementation of the v1 Pop request protocol.
 
 *******************************************************************************/
 
-class PopImpl_v0 : PopProtocol_v0
+class PopImpl_v1 : PopProtocol_v1
 {
     import fakedmq.Storage;
     import dmqproto.node.neo.request.core.IRequestResources;

--- a/src/fakedmq/neo/request/Push.d
+++ b/src/fakedmq/neo/request/Push.d
@@ -28,7 +28,7 @@ import ocean.transition;
 
 *******************************************************************************/
 
-class PushImpl_v2 : PushProtocol_v2
+class PushImpl_v3 : PushProtocol_v3
 {
     import fakedmq.Storage;
     import dmqproto.node.neo.request.core.IRequestResources;


### PR DESCRIPTION
Updating to swarm v5 caused a hidden protocol change in all requests. Two problems:
1. The request versions in dmqproto were not updated to match.
2. This change also means that all previous request versions are unsupported by a DMQ node compiled with dmqproto v14.1.0 (the protocol will mismatch what the client expects).

This PR updates the request versions, as required (point 1), but does not address point 2. Point 2 is an issue of what is deployed / used in production.