### PR TITLE
Make Request imports inside NeoSupport mixin public

### DIFF
--- a/src/dmqproto/client/mixins/NeoSupport.d
+++ b/src/dmqproto/client/mixins/NeoSupport.d
@@ -48,9 +48,9 @@ template NeoSupport ( )
 
         ***********************************************************************/
 
-        import Consume = dmqproto.client.request.Consume;
-        import Push = dmqproto.client.request.Push;
-        import Pop = dmqproto.client.request.Pop;
+        public import Consume = dmqproto.client.request.Consume;
+        public import Push = dmqproto.client.request.Push;
+        public import Pop = dmqproto.client.request.Pop;
 
         /***********************************************************************
 


### PR DESCRIPTION
Since the user's code should not import the request modules, but just
use the modules imported in the client, these modules needs to be
public, so the visibility is preserved with the DMD v2.071+