### PR TITLE
Don't use deprecated features if using swarm v5.1.x or newer

### DIFF
--- a/src/dmqproto/client/mixins/NeoSupport.d
+++ b/src/dmqproto/client/mixins/NeoSupport.d
@@ -22,6 +22,7 @@ module dmqproto.client.mixins.NeoSupport;
 
 template NeoSupport ( )
 {
+    import ocean.core.VersionCheck;
     import dmqproto.client.internal.SharedResources;
 
     /***************************************************************************
@@ -625,7 +626,9 @@ template NeoSupport ( )
     {
         this.neo = new Neo(config, Neo.Settings(conn_notifier, new SharedResources));
         this.blocking = new TaskBlocking;
-        this.neo.enableSocketNoDelay();
+
+        static if (!hasFeaturesFrom!("swarm", 5, 1))
+            this.neo.enableSocketNoDelay();
     }
 
 
@@ -652,6 +655,8 @@ template NeoSupport ( )
     {
         this.neo = new Neo(auth_name, auth_key, Neo.Settings(conn_notifier, new SharedResources));
         this.blocking = new TaskBlocking;
-        this.neo.enableSocketNoDelay();
+
+        static if (!hasFeaturesFrom!("swarm", 5, 1))
+            this.neo.enableSocketNoDelay();
     }
 }

--- a/src/dmqtest/DmqClient.d
+++ b/src/dmqtest/DmqClient.d
@@ -20,6 +20,7 @@ module dmqtest.DmqClient;
 *******************************************************************************/
 
 import ocean.transition;
+import ocean.core.VersionCheck;
 import ocean.util.log.Logger;
 
 /*******************************************************************************
@@ -883,7 +884,9 @@ class DmqClient
         this.raw_client = new RawClient(theScheduler.epoll, auth_name,
             auth_key.content,
             &this.neo.connectionNotifier, connections);
-        this.raw_client.neo.enableSocketNoDelay();
+
+        static if (!hasFeaturesFrom!("swarm", 5, 1))
+            this.raw_client.neo.enableSocketNoDelay();
     }
 
     /***************************************************************************

--- a/src/fakedmq/DmqNode.d
+++ b/src/fakedmq/DmqNode.d
@@ -20,6 +20,7 @@ module fakedmq.DmqNode;
 *******************************************************************************/
 
 import ocean.transition;
+import ocean.core.VersionCheck;
 
 import ocean.util.log.Logger;
 
@@ -106,7 +107,10 @@ public class DmqNode
         Options neo_options;
         neo_options.requests = request_handlers;
         neo_options.epoll = epoll;
-        neo_options.no_delay = true; // favour network turn-around over packet efficiency
+
+        static if (!hasFeaturesFrom!("swarm", 5, 1))
+            neo_options.no_delay = true; // favour network turn-around over packet efficiency
+
         neo_options.credentials_map["test"] = Key.init;
 
         ushort neo_port = node_item.Port;


### PR DESCRIPTION
All variants of `enableSocketNoDelay` are deprecated in swarm v5.1.0,
and we don't need to use them if we have swarm newer than v5.1.0,
which will avoid deprecations.