### PR TITLE
Add version decorator for structs in fake DMQ.

### DIFF
--- a/relnotes/versioned_struct_fakenode.feature.md
+++ b/relnotes/versioned_struct_fakenode.feature.md
@@ -1,0 +1,6 @@
+### Turtle node versioned struct support.
+
+`turtle.env.Dmq`
+
+Versioned structs are now supported directly through the API for `push` and
+`pop`.


### PR DESCRIPTION
Following DHT convention, versioned structs will be supported when
passing in the struct value.

I've taken the implementation directly from dhtproto.