### PR TITLE
Allocate Stats instance as scope in usage example

### DIFF
--- a/src/dmqproto/client/UsageExamples.d
+++ b/src/dmqproto/client/UsageExamples.d
@@ -406,7 +406,7 @@ unittest
     void getStats ( DmqClient dmq )
     {
         // See Stats in swarm.neo.client.mixins.ClientCore
-        auto stats = dmq.neo.new Stats;
+        scope stats = dmq.neo.new Stats;
 
         // Connection stats.
         Stdout.formatln("DMQ nodes registered with client: {}",


### PR DESCRIPTION
Just to show the intended usage.