### PR TITLE
Remove unnecessary parser field from RequestHandler class

### DIFF
--- a/src/dmqproto/node/neo/request/Consume.d
+++ b/src/dmqproto/node/neo/request/Consume.d
@@ -140,7 +140,7 @@ public abstract scope class ConsumeProtocol_v4: RequestHandler
     {
         cstring channel_name;
         cstring subscriber_name;
-        this.parser.parseBody(msg_payload, channel_name, subscriber_name);
+        this.ed.message_parser.parseBody(msg_payload, channel_name, subscriber_name);
 
         if ( !this.prepareChannel(resources, channel_name, subscriber_name) )
         {
@@ -375,7 +375,7 @@ public abstract scope class ConsumeProtocol_v4: RequestHandler
         istring file = __FILE__, int line = __LINE__ )
     {
         MessageType msg_type;
-        this.parser.parseBody(msg_payload, msg_type);
+        this.ed.message_parser.parseBody(msg_payload, msg_type);
         if (msg_type != msg_type.Stop)
             this.ed.shutdownWithProtocolError(
                 "Consume: Message received from the client is not Stop as expected",

--- a/src/dmqproto/node/neo/request/Pop.d
+++ b/src/dmqproto/node/neo/request/Pop.d
@@ -62,7 +62,7 @@ public abstract class PopProtocol_v1: RequestHandler
     {
         cstring channel_name;
 
-        this.parser.parseBody(msg_payload, channel_name);
+        this.ed.message_parser.parseBody(msg_payload, channel_name);
 
         bool subscribed;
 

--- a/src/dmqproto/node/neo/request/Push.d
+++ b/src/dmqproto/node/neo/request/Push.d
@@ -64,15 +64,15 @@ public abstract class PushProtocol_v3: RequestHandler
         // Acquire a buffer to contain slices to the channel names in the
         // message payload (i.e. not a buffer of buffers, a buffer of slices)
         auto channel_names = VoidBufferAsArrayOf!(cstring)(resources.getVoidBuffer());
-        channel_names.length = *this.parser.getValue!(ubyte)(msg_payload);
+        channel_names.length = *this.ed.message_parser.getValue!(ubyte)(msg_payload);
 
         foreach ( ref channel_name; channel_names.array )
         {
-            channel_name = this.parser.getArray!(Const!(char))(msg_payload);
+            channel_name = this.ed.message_parser.getArray!(Const!(char))(msg_payload);
         }
 
         Const!(void)[] value;
-        this.parser.parseBody(msg_payload, value);
+        this.ed.message_parser.parseBody(msg_payload, value);
 
         if ( this.prepareChannels(resources, channel_names.array) )
         {

--- a/src/dmqproto/node/neo/request/core/RequestHandler.d
+++ b/src/dmqproto/node/neo/request/core/RequestHandler.d
@@ -48,14 +48,6 @@ abstract class RequestHandler: IRequest
 
     /***************************************************************************
 
-        Message parser
-
-    ***************************************************************************/
-
-    protected RequestOnConn.EventDispatcher.MessageParser parser;
-
-    /***************************************************************************
-
         Called by the connection handler after the request code and version have
         been parsed from a message received over the connection, and the
         request-supported code sent in response.
@@ -82,7 +74,6 @@ abstract class RequestHandler: IRequest
         verify(this.resources !is null);
 
         this.ed = connection.event_dispatcher;
-        this.parser = this.ed.message_parser;
 
         void[]* buf = this.resources.getVoidBuffer();
         (*buf).length = init_payload.length;


### PR DESCRIPTION
This class instance is already accessible through the `ed` field using `ed.message_parser`, which is how it is used in all other d**protos.  The use of a separate `parser` field looks like a slightly mispurposed
attempt at DRY, which as a by-product relies on an implicitly public import of `MessageParser` inside the `EventDispatcher` class.

Such implicitly public imports will break as of version 2.087.0 of the D frontend, so it seems better to just drop this usage and use the event dispatcher instance directly.

An alternative would be to have defined a `parser` method which returns `ed.message_parser` (we can use `auto` return type to avoid any need to rely on implicit imports), but this seems a bit overkill, and both this and the original class field just obfuscate ownership of the parser.