### PR TITLE
Replace `Const!` with `const`

### DIFF
--- a/neotest/main.d
+++ b/neotest/main.d
@@ -64,7 +64,7 @@ abstract class DmqTest
     abstract protected void go ( );
 
     protected void popNotifier ( DmqClient.Neo.Pop.Notification info,
-        Const!(DmqClient.Neo.Pop.Args) args )
+        const(DmqClient.Neo.Pop.Args) args )
     {
         with ( info.Active ) switch ( info.active )
         {
@@ -125,7 +125,7 @@ abstract class DmqTest
     }
 
     protected void pushNotifier ( DmqClient.Neo.Push.Notification info,
-        Const!(DmqClient.Neo.Push.Args) args )
+        const(DmqClient.Neo.Push.Args) args )
     {
         with ( info.Active ) switch ( info.active )
         {
@@ -177,7 +177,7 @@ abstract class DmqTest
     }
 
     protected void consumeNotifier ( DmqClient.Neo.Consume.Notification info,
-        Const!(DmqClient.Neo.Consume.Args) args )
+        const(DmqClient.Neo.Consume.Args) args )
     {
         with ( info.Active ) switch ( info.active )
         {

--- a/src/dmqproto/client/UsageExamples.d
+++ b/src/dmqproto/client/UsageExamples.d
@@ -142,7 +142,7 @@ unittest
         // the Push request. See dmqproto.client.request.Push for details of
         // the parameters of the notifier. (Each request has a module like
         // this, defining its public API.)
-        private void pushNotifier ( Push.Notification info, Const!(Push.Args) args )
+        private void pushNotifier ( Push.Notification info, const(Push.Args) args )
         {
             // `info` is a smart union, where each member of the union
             // represents one possible notification. `info.active` denotes
@@ -280,7 +280,7 @@ unittest
         // details of the parameters of the notifier. (Each request has a
         // module like this, defining its public API.)
         private void consumeNotifier ( Consume.Notification info,
-            Const!(Consume.Args) args )
+            const(Consume.Args) args )
         {
             // `info` is a smart union, where each member of the union
             // represents one possible notification. `info.active` denotes
@@ -386,7 +386,7 @@ unittest
         // Start a Consume request
         auto request_id = dmq.neo.consume(
             "channel",
-            ( Consume.Notification, Const!(Consume.Args) ) { },
+            ( Consume.Notification, const(Consume.Args) ) { },
             dmq.neo.Subscriber("subscriber")
         );
 

--- a/src/dmqproto/client/legacy/internal/RequestSetup.d
+++ b/src/dmqproto/client/legacy/internal/RequestSetup.d
@@ -255,7 +255,7 @@ public template Channels ( )
 
     ***************************************************************************/
 
-    private Const!(char[])[] channel_names;
+    private const(char[])[] channel_names;
 
     /***************************************************************************
 
@@ -269,7 +269,7 @@ public template Channels ( )
 
     ***************************************************************************/
 
-    public This* channels ( Const!(char[])[] channels )
+    public This* channels ( const(char[])[] channels )
     {
         verify(!!channels.length, "multi-channel request: empty list of channels");
 

--- a/src/dmqproto/client/legacy/internal/request/params/IODelegates.d
+++ b/src/dmqproto/client/legacy/internal/request/params/IODelegates.d
@@ -48,7 +48,7 @@ import dmqproto.client.legacy.internal.request.model.IProducer;
 
 *******************************************************************************/
 
-public alias Const!(char[]) delegate (RequestContext) PutValueDg;
+public alias const(char[]) delegate (RequestContext) PutValueDg;
 
 
 /*******************************************************************************
@@ -57,7 +57,7 @@ public alias Const!(char[]) delegate (RequestContext) PutValueDg;
 
 *******************************************************************************/
 
-public alias void delegate (RequestContext, Const!(char[])) GetValueDg;
+public alias void delegate (RequestContext, const(char[])) GetValueDg;
 
 
 /*******************************************************************************
@@ -67,7 +67,7 @@ public alias void delegate (RequestContext, Const!(char[])) GetValueDg;
 
 *******************************************************************************/
 
-public alias void delegate (RequestContext, Const!(char[]), ushort, Const!(char[])) GetNodeValueDg;
+public alias void delegate (RequestContext, const(char[]), ushort, const(char[])) GetNodeValueDg;
 
 
 /*******************************************************************************
@@ -77,7 +77,7 @@ public alias void delegate (RequestContext, Const!(char[]), ushort, Const!(char[
 
 *******************************************************************************/
 
-public alias void delegate (RequestContext, Const!(char[]), ushort, size_t) GetNumConnectionsDg;
+public alias void delegate (RequestContext, const(char[]), ushort, size_t) GetNumConnectionsDg;
 
 
 /*******************************************************************************

--- a/src/dmqproto/client/legacy/internal/request/params/RequestParams.d
+++ b/src/dmqproto/client/legacy/internal/request/params/RequestParams.d
@@ -185,7 +185,7 @@ public class RequestParams : IChannelRequestParams
 
     ***************************************************************************/
 
-    public Const!(char[])[] channels;
+    public const(char[])[] channels;
 
     /***************************************************************************
 

--- a/src/dmqproto/client/mixins/NeoSupport.d
+++ b/src/dmqproto/client/mixins/NeoSupport.d
@@ -142,8 +142,8 @@ template NeoSupport ( )
             scope parse_subscriber = (Subscriber sub) { subscriber = sub.name; };
             setupOptionalArgs!(options.length)(options, parse_subscriber);
 
-            auto params = Const!(Internals.Consume.UserSpecifiedParams)(
-                Const!(Consume.Args)(channel, subscriber), notifier
+            auto params = const(Internals.Consume.UserSpecifiedParams)(
+                const(Consume.Args)(channel, subscriber), notifier
             );
 
             auto id = this.assign!(Internals.Consume)(params);
@@ -171,7 +171,7 @@ template NeoSupport ( )
 
         ***********************************************************************/
 
-        public RequestId push ( cstring channel, Const!(void)[] value,
+        public RequestId push ( cstring channel, const(void)[] value,
             scope Push.Notifier notifier )
         {
             return this.push((&channel)[0 .. 1], value, notifier);
@@ -199,7 +199,7 @@ template NeoSupport ( )
 
         ***********************************************************************/
 
-        public RequestId push ( Const!(char[][]) channels, Const!(void)[] value,
+        public RequestId push ( const(char[][]) channels, const(void)[] value,
             scope Push.Notifier notifier )
         {
             // Validate the channels list. The number of channels is transmitted
@@ -208,8 +208,8 @@ template NeoSupport ( )
             enforce(channels.length <= 255,
                 "Push may operate on at most 255 channels");
 
-            auto params = Const!(Internals.Push.UserSpecifiedParams)(
-                Const!(Push.Args)(channels, value), notifier
+            auto params = const(Internals.Push.UserSpecifiedParams)(
+                const(Push.Args)(channels, value), notifier
             );
 
             auto id = this.assign!(Internals.Push)(params);
@@ -238,8 +238,8 @@ template NeoSupport ( )
 
         public RequestId pop ( cstring channel, scope Pop.Notifier notifier )
         {
-            auto params = Const!(Internals.Pop.UserSpecifiedParams)(
-                Const!(Pop.Args)(channel), notifier
+            auto params = const(Internals.Pop.UserSpecifiedParams)(
+                const(Pop.Args)(channel), notifier
             );
 
             auto id = this.assign!(Internals.Pop)(params);
@@ -390,7 +390,7 @@ template NeoSupport ( )
 
         ***********************************************************************/
 
-        public PushResult push ( cstring channel, Const!(void)[] value,
+        public PushResult push ( cstring channel, const(void)[] value,
             scope Neo.Push.Notifier notifier = null )
         {
             return this.push((&channel)[0 .. 1], value, notifier);
@@ -415,7 +415,7 @@ template NeoSupport ( )
 
         ***********************************************************************/
 
-        public PushResult push ( cstring[] channels, Const!(void)[] value,
+        public PushResult push ( cstring[] channels, const(void)[] value,
             scope Neo.Push.Notifier user_notifier = null )
         {
             auto task = Task.getThis();
@@ -430,7 +430,7 @@ template NeoSupport ( )
 
             FinishedStatus state;
 
-            void notifier ( Neo.Push.Notification info, Const!(Neo.Push.Args) args )
+            void notifier ( Neo.Push.Notification info, const(Neo.Push.Args) args )
             {
                 if ( user_notifier )
                     user_notifier(info, args);
@@ -529,7 +529,7 @@ template NeoSupport ( )
 
             FinishedStatus state;
 
-            void notifier ( Neo.Pop.Notification info, Const!(Neo.Pop.Args) args )
+            void notifier ( Neo.Pop.Notification info, const(Neo.Pop.Args) args )
             {
                 if ( user_notifier )
                     user_notifier(info, args);

--- a/src/dmqproto/client/request/Consume.d
+++ b/src/dmqproto/client/request/Consume.d
@@ -163,7 +163,7 @@ public alias SmartUnion!(NotificationUnion) Notification;
 
 *******************************************************************************/
 
-public alias void delegate ( Notification, Const!(Args) ) Notifier;
+public alias void delegate ( Notification, const(Args) ) Notifier;
 
 /*******************************************************************************
 

--- a/src/dmqproto/client/request/Pop.d
+++ b/src/dmqproto/client/request/Pop.d
@@ -97,4 +97,4 @@ public alias SmartUnion!(NotificationUnion) Notification;
 
 *******************************************************************************/
 
-public alias void delegate ( Notification, Const!(Args) ) Notifier;
+public alias void delegate ( Notification, const(Args) ) Notifier;

--- a/src/dmqproto/client/request/Push.d
+++ b/src/dmqproto/client/request/Push.d
@@ -86,4 +86,4 @@ public alias SmartUnion!(NotificationUnion) Notification;
 
 *******************************************************************************/
 
-public alias void delegate ( Notification, Const!(Args) ) Notifier;
+public alias void delegate ( Notification, const(Args) ) Notifier;

--- a/src/dmqproto/client/request/internal/Consume.d
+++ b/src/dmqproto/client/request/internal/Consume.d
@@ -335,7 +335,7 @@ private scope class ConsumeHandler
         private void[]* batch_buffer;
 
         /// Slices the records in *batch_buffer that haven't been processed yet.
-        private Const!(void)[] remaining_batch = null;
+        private const(void)[] remaining_batch = null;
 
         /// The fiber.
         private MessageFiber fiber;
@@ -463,7 +463,7 @@ private scope class ConsumeHandler
 
                     this.passRecordToUser(
                         this.outer.conn.message_parser.getArray
-                        !(Const!(void))(this.remaining_batch)
+                        !(const(void))(this.remaining_batch)
                     );
                 }
 
@@ -617,7 +617,7 @@ private scope class ConsumeHandler
                 final switch (msg.type)
                 {
                     case MessageType.Records:
-                        Const!(void)[] received_record_batch;
+                        const(void)[] received_record_batch;
                         this.outer.conn.message_parser.parseBody(
                             msg.payload, received_record_batch
                         );

--- a/src/dmqproto/client/request/internal/Pop.d
+++ b/src/dmqproto/client/request/internal/Pop.d
@@ -150,7 +150,7 @@ public struct Pop
                     conn.receive(
                         ( const(void)[] const_payload )
                         {
-                            Const!(void)[] payload = const_payload;
+                            const(void)[] payload = const_payload;
                             auto status =
                                 *conn.message_parser.getValue!(StatusCode)(payload);
 

--- a/src/dmqproto/node/neo/request/Consume.d
+++ b/src/dmqproto/node/neo/request/Consume.d
@@ -136,7 +136,7 @@ public abstract scope class ConsumeProtocol_v4: RequestHandler
     ***************************************************************************/
 
     override protected void handle ( RequestOnConn connection,
-        IRequestResources resources, Const!(void)[] msg_payload )
+        IRequestResources resources, const(void)[] msg_payload )
     {
         cstring channel_name;
         cstring subscriber_name;

--- a/src/dmqproto/node/neo/request/Pop.d
+++ b/src/dmqproto/node/neo/request/Pop.d
@@ -58,7 +58,7 @@ public abstract class PopProtocol_v1: RequestHandler
     ***************************************************************************/
 
     override protected void handle ( RequestOnConn connection,
-        IRequestResources resources, Const!(void)[] msg_payload )
+        IRequestResources resources, const(void)[] msg_payload )
     {
         cstring channel_name;
 

--- a/src/dmqproto/node/neo/request/Push.d
+++ b/src/dmqproto/node/neo/request/Push.d
@@ -59,7 +59,7 @@ public abstract class PushProtocol_v3: RequestHandler
     ***************************************************************************/
 
     override protected void handle ( RequestOnConn connection,
-        IRequestResources resources, Const!(void)[] msg_payload )
+        IRequestResources resources, const(void)[] msg_payload )
     {
         // Acquire a buffer to contain slices to the channel names in the
         // message payload (i.e. not a buffer of buffers, a buffer of slices)
@@ -68,10 +68,10 @@ public abstract class PushProtocol_v3: RequestHandler
 
         foreach ( ref channel_name; channel_names.array )
         {
-            channel_name = this.ed.message_parser.getArray!(Const!(char))(msg_payload);
+            channel_name = this.ed.message_parser.getArray!(const(char))(msg_payload);
         }
 
-        Const!(void)[] value;
+        const(void)[] value;
         this.ed.message_parser.parseBody(msg_payload, value);
 
         if ( this.prepareChannels(resources, channel_names.array) )

--- a/src/dmqproto/node/neo/request/core/RequestHandler.d
+++ b/src/dmqproto/node/neo/request/core/RequestHandler.d
@@ -36,7 +36,7 @@ abstract class RequestHandler: IRequest
 
     ***************************************************************************/
 
-    private Const!(void)[] msg_payload;
+    private const(void)[] msg_payload;
 
     /***************************************************************************
 
@@ -67,7 +67,7 @@ abstract class RequestHandler: IRequest
     ***************************************************************************/
 
     public void handle ( RequestOnConn connection, Object resources,
-        Const!(void)[] init_payload )
+        const(void)[] init_payload )
     {
         this.connection = connection;
         this.resources = cast(IRequestResources)resources;
@@ -96,5 +96,5 @@ abstract class RequestHandler: IRequest
     ***************************************************************************/
 
     abstract protected void handle ( RequestOnConn connection,
-        IRequestResources resources, Const!(void)[] msg_payload );
+        IRequestResources resources, const(void)[] msg_payload );
 }

--- a/src/dmqproto/node/request/Pop.d
+++ b/src/dmqproto/node/request/Pop.d
@@ -78,5 +78,5 @@ public abstract scope class Pop : SingleChannel
 
     ***************************************************************************/
 
-    abstract protected Const!(void)[] getNextValue ( cstring channel_name );
+    abstract protected const(void)[] getNextValue ( cstring channel_name );
 }

--- a/src/dmqproto/node/request/model/MultiChannel.d
+++ b/src/dmqproto/node/request/model/MultiChannel.d
@@ -40,7 +40,7 @@ public abstract scope class MultiChannel : DmqCommand
 
     ***************************************************************************/
 
-    protected Const!(cstring)[] channels;
+    protected const(cstring)[] channels;
 
     /***************************************************************************
 

--- a/src/dmqtest/DmqClient.d
+++ b/src/dmqtest/DmqClient.d
@@ -302,7 +302,7 @@ class DmqClient
 
         ***********************************************************************/
 
-        public void push ( Const!(char[])[] channels, cstring data )
+        public void push ( const(char[])[] channels, cstring data )
         {
             auto res = this.outer.raw_client.blocking.push(channels.dup, data);
 
@@ -364,7 +364,7 @@ class DmqClient
         {
             void[] result;
 
-            void notify ( Pop.Notification info, Const!(Pop.Args) args )
+            void notify ( Pop.Notification info, const(Pop.Args) args )
             {
                 notifications[info.active]++;
             }
@@ -507,7 +507,7 @@ class DmqClient
 
                 ***************************************************************/
 
-                public Const!(RawClient.Neo.RequestId)[] opSlice ( )
+                public const(RawClient.Neo.RequestId)[] opSlice ( )
                 {
                     return this.ids;
                 }
@@ -773,7 +773,7 @@ class DmqClient
             *******************************************************************/
 
             private void notifier ( Consume.Notification info,
-                Const!(Consume.Args) args )
+                const(Consume.Args) args )
             {
                 with ( info.Active ) switch ( info.active )
                 {

--- a/src/dmqtest/DmqTestCase.d
+++ b/src/dmqtest/DmqTestCase.d
@@ -76,7 +76,7 @@ abstract class DmqTestCase : TestCase
 
     ***************************************************************************/
 
-    protected Const!(char[])[] channels;
+    protected const(char[])[] channels;
 
     /***************************************************************************
 
@@ -88,7 +88,7 @@ abstract class DmqTestCase : TestCase
 
     ***************************************************************************/
 
-    protected this ( Const!(char[])[] channels = null )
+    protected this ( const(char[])[] channels = null )
     {
         if (channels.length)
         {
@@ -191,7 +191,7 @@ class CheckedDmqTestCase : DmqTestCase
         Writer's constructor is expected to accept no arguments.
 
         Expected form of Checker's constructor:
-            this ( Const!(char[])[] channels )
+            this ( const(char[])[] channels )
 
         Params:
             writer = the writer which is used to write data to the DMQ
@@ -645,7 +645,7 @@ class SubscribeDmqTestCase : DmqTestCase
         /*
          * Push a bunch of records to the queue channel.
          */
-        Const!(char[])[] pushed_records = this.records;
+        const(char[])[] pushed_records = this.records;
         this.writer.run(pushed_records);
 
         /*
@@ -743,7 +743,7 @@ class SubscribeDmqTestCase : DmqTestCase
 
     ***************************************************************************/
 
-    private void startConsumers ( Const!(char[])[] subscriber_names ... )
+    private void startConsumers ( const(char[])[] subscriber_names ... )
     {
         foreach (channel; this.channels)
         {
@@ -771,8 +771,8 @@ class SubscribeDmqTestCase : DmqTestCase
 
     ***************************************************************************/
 
-    private void consume ( Const!(char[])[] expected_records,
-        Const!(char[])[] subscriber_names ... )
+    private void consume ( const(char[])[] expected_records,
+        const(char[])[] subscriber_names ... )
     in
     {
         assert(expected_records.length);
@@ -780,12 +780,12 @@ class SubscribeDmqTestCase : DmqTestCase
     }
     body
     {
-        cstring[][Const!(char[])][Const!(char[])]
+        cstring[][const(char[])][const(char[])]
             records_by_channel_and_subscriber;
 
         foreach (channel; this.channels)
         {
-            cstring[][Const!(char[])] records_by_subscriber;
+            cstring[][const(char[])] records_by_subscriber;
             foreach (subscriber_name; subscriber_names)
             {
                 assert(!(subscriber_name in records_by_subscriber),
@@ -808,7 +808,7 @@ class SubscribeDmqTestCase : DmqTestCase
             foreach (record; this.consumers.received_records)
             {
                 test!(">")(records_by_channel_and_subscriber.length, 0);
-                cstring[][Const!(char[])]* records_by_subscriber =
+                cstring[][const(char[])]* records_by_subscriber =
                     record.channel in records_by_channel_and_subscriber;
                 test!("!is")(records_by_subscriber, null);
                 test!(">")(records_by_subscriber.length, 0);

--- a/src/dmqtest/cases/checkers/ConsumeChecker.d
+++ b/src/dmqtest/cases/checkers/ConsumeChecker.d
@@ -45,7 +45,7 @@ private abstract class ConsumeCheckerBase : IChecker
 
     ***************************************************************************/
 
-    private DmqClient.Consumer[Const!(char[])] consumers;
+    private DmqClient.Consumer[const(char[])] consumers;
 
     /***************************************************************************
 
@@ -64,7 +64,7 @@ private abstract class ConsumeCheckerBase : IChecker
 
     ***************************************************************************/
 
-    protected this ( Const!(char[])[] channels )
+    protected this ( const(char[])[] channels )
     {
         foreach (channel; channels)
             this.consumers[channel] = null;
@@ -103,7 +103,7 @@ private abstract class ConsumeCheckerBase : IChecker
 
     ***************************************************************************/
 
-    override public void check ( Const!(char[])[] records )
+    override public void check ( const(char[])[] records )
     {
         foreach ( channel, consumer; this.consumers )
         {
@@ -171,7 +171,7 @@ class PreConsumeChecker : ConsumeCheckerBase
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] test_channels )
+    public this ( const(char[])[] test_channels )
     {
         super(test_channels);
     }
@@ -211,7 +211,7 @@ class PostConsumeChecker : ConsumeCheckerBase
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] test_channels )
+    public this ( const(char[])[] test_channels )
     {
         super(test_channels);
     }
@@ -231,7 +231,7 @@ class PostConsumeChecker : ConsumeCheckerBase
 
     ***************************************************************************/
 
-    override public void check ( Const!(char[])[] records )
+    override public void check ( const(char[])[] records )
     {
         this.startConsumers();
         super.check(records);
@@ -276,7 +276,7 @@ private abstract class NeoConsumeCheckerBase : IChecker
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] test_channels )
+    public this ( const(char[])[] test_channels )
     {
         this.local = new RecordIndex(test_channels);
     }
@@ -314,7 +314,7 @@ private abstract class NeoConsumeCheckerBase : IChecker
 
     ***************************************************************************/
 
-    override public void check ( Const!(char[])[] records )
+    override public void check ( const(char[])[] records )
     {
         size_t popped;
         auto expected_record_count = this.local.fill(records);
@@ -379,7 +379,7 @@ class NeoPreConsumeChecker : NeoConsumeCheckerBase
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] test_channels )
+    public this ( const(char[])[] test_channels )
     {
         super(test_channels);
     }
@@ -420,7 +420,7 @@ class NeoPostConsumeChecker : NeoConsumeCheckerBase
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] test_channels )
+    public this ( const(char[])[] test_channels )
     {
         super(test_channels);
     }
@@ -440,7 +440,7 @@ class NeoPostConsumeChecker : NeoConsumeCheckerBase
 
     ***************************************************************************/
 
-    override public void check ( Const!(char[])[] records )
+    override public void check ( const(char[])[] records )
     {
         this.startConsumers();
         super.check(records);
@@ -468,7 +468,7 @@ private abstract class NeoSuspendConsumeCheckerBase : NeoConsumeCheckerBase
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] test_channels )
+    public this ( const(char[])[] test_channels )
     {
         super(test_channels);
     }
@@ -488,7 +488,7 @@ private abstract class NeoSuspendConsumeCheckerBase : NeoConsumeCheckerBase
 
     ***************************************************************************/
 
-    override public void check ( Const!(char[])[] records )
+    override public void check ( const(char[])[] records )
     {
         size_t popped;
         auto expected_record_count = this.local.fill(records);
@@ -542,7 +542,7 @@ class NeoSuspendPreConsumeChecker : NeoSuspendConsumeCheckerBase
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] test_channels )
+    public this ( const(char[])[] test_channels )
     {
         super(test_channels);
     }
@@ -582,7 +582,7 @@ class NeoSuspendPostConsumeChecker : NeoSuspendConsumeCheckerBase
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] test_channels )
+    public this ( const(char[])[] test_channels )
     {
         super(test_channels);
     }
@@ -602,7 +602,7 @@ class NeoSuspendPostConsumeChecker : NeoSuspendConsumeCheckerBase
 
     ***************************************************************************/
 
-    override public void check ( Const!(char[])[] records )
+    override public void check ( const(char[])[] records )
     {
         this.startConsumers();
         super.check(records);

--- a/src/dmqtest/cases/checkers/PopChecker.d
+++ b/src/dmqtest/cases/checkers/PopChecker.d
@@ -33,7 +33,7 @@ private abstract class PopCheckerBase : IChecker
 
     ***************************************************************************/
 
-    public Const!(char[][]) channels;
+    public const(char[][]) channels;
 
     /***************************************************************************
 
@@ -52,7 +52,7 @@ private abstract class PopCheckerBase : IChecker
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] test_channels )
+    public this ( const(char[])[] test_channels )
     {
         this.channels = test_channels;
     }
@@ -85,7 +85,7 @@ private abstract class PopCheckerBase : IChecker
 
     ***************************************************************************/
 
-    override public void check ( Const!(char[])[] records )
+    override public void check ( const(char[])[] records )
     {
         foreach ( channel; this.channels )
         {
@@ -122,7 +122,7 @@ class PopChecker : PopCheckerBase
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] test_channels )
+    public this ( const(char[])[] test_channels )
     {
         super(test_channels);
     }
@@ -154,7 +154,7 @@ class NeoPopChecker : PopCheckerBase
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] channels )
+    public this ( const(char[])[] channels )
     {
         super(channels);
     }
@@ -183,7 +183,7 @@ class ParallelNeoPopChecker : IChecker
 
     ***************************************************************************/
 
-    public Const!(char[][]) channels;
+    public const(char[][]) channels;
 
     /***************************************************************************
 
@@ -202,7 +202,7 @@ class ParallelNeoPopChecker : IChecker
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] test_channels )
+    public this ( const(char[])[] test_channels )
     {
         this.channels = test_channels;
     }
@@ -235,7 +235,7 @@ class ParallelNeoPopChecker : IChecker
 
     ***************************************************************************/
 
-    override public void check ( Const!(char[])[] records )
+    override public void check ( const(char[])[] records )
     {
         auto popped = new uint[this.channels.length];
         auto expected_record_count = records.length * popped.length;

--- a/src/dmqtest/cases/checkers/model/IChecker.d
+++ b/src/dmqtest/cases/checkers/model/IChecker.d
@@ -46,6 +46,6 @@ abstract class IChecker
 
     ***************************************************************************/
 
-    abstract public void check ( Const!(char[])[] records );
+    abstract public void check ( const(char[])[] records );
 }
 

--- a/src/dmqtest/cases/writers/ProduceWriter.d
+++ b/src/dmqtest/cases/writers/ProduceWriter.d
@@ -43,7 +43,7 @@ abstract class ProduceWriterBase : IWriter
 
     ***************************************************************************/
 
-    this ( Const!(char[])[] channels ... ) {super(channels);}
+    this ( const(char[])[] channels ... ) {super(channels);}
 
     /***************************************************************************
 
@@ -56,7 +56,7 @@ abstract class ProduceWriterBase : IWriter
 
     ***************************************************************************/
 
-    override public void run ( Const!(char[])[] records )
+    override public void run ( const(char[])[] records )
     {
         assert(this.producer is null);
         this.producer = this.startProduce();

--- a/src/dmqtest/cases/writers/model/IWriter.d
+++ b/src/dmqtest/cases/writers/model/IWriter.d
@@ -23,7 +23,7 @@ abstract class IWriter
 
     ***************************************************************************/
 
-    public Const!(char[])[] test_channels;
+    public const(char[])[] test_channels;
 
     /***************************************************************************
 
@@ -42,7 +42,7 @@ abstract class IWriter
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] test_channels ... )
+    public this ( const(char[])[] test_channels ... )
     {
         this.test_channels = test_channels.dup;
     }
@@ -72,7 +72,7 @@ abstract class IWriter
 
     ***************************************************************************/
 
-    public void run ( Const!(char[])[] records )
+    public void run ( const(char[])[] records )
     in
     {
         assert(this.dmq, "Call prepare first");

--- a/src/dmqtest/util/Record.d
+++ b/src/dmqtest/util/Record.d
@@ -68,8 +68,8 @@ T[] sort ( T ) ( T[] array )
 }
 
 /// `qsort` element comparison callback function, wraps `typeid(T).compare`.
-extern (C) private int cmp ( T ) ( scope Const!(void*) a,
-        scope Const!(void*) b )
+extern (C) private int cmp ( T ) ( scope const(void*) a,
+        scope const(void*) b )
 {
     return typeid(T).compare(a, b);
 }

--- a/src/dmqtest/util/RecordIndex.d
+++ b/src/dmqtest/util/RecordIndex.d
@@ -33,7 +33,7 @@ class RecordIndex
 
     ***************************************************************************/
 
-    private Const!(char[])[][Const!(char[])] records_per_channel;
+    private const(char[])[][const(char[])] records_per_channel;
 
     /***************************************************************************
 
@@ -44,7 +44,7 @@ class RecordIndex
 
     ***************************************************************************/
 
-    public this ( Const!(char[])[] channels ... )
+    public this ( const(char[])[] channels ... )
     {
         foreach (channel; channels)
             this.records_per_channel[channel] = null;
@@ -66,7 +66,7 @@ class RecordIndex
 
     ***************************************************************************/
 
-    public size_t fill ( Const!(char[])[] records )
+    public size_t fill ( const(char[])[] records )
     {
         foreach (ref records_in_channel; this.records_per_channel)
             records_in_channel = records;

--- a/src/fakedmq/Storage.d
+++ b/src/fakedmq/Storage.d
@@ -556,7 +556,7 @@ class Queue
 
     ***************************************************************************/
 
-    public Const!(ValueType) pop ( )
+    public const(ValueType) pop ( )
     {
         enforce!(EmptyChannelException)(this.queue.length != 0);
 

--- a/src/fakedmq/request/Pop.d
+++ b/src/fakedmq/request/Pop.d
@@ -52,7 +52,7 @@ public scope class Pop : Protocol.Pop
 
     ***************************************************************************/
 
-    override protected Const!(void)[] getNextValue ( cstring channel_name )
+    override protected const(void)[] getNextValue ( cstring channel_name )
     {
         if (auto channel = global_storage.get(channel_name))
         {

--- a/src/turtle/env/Dmq.d
+++ b/src/turtle/env/Dmq.d
@@ -110,7 +110,7 @@ public class Dmq : Node!(DmqNode, "dmq")
     {
         mstring serialized_data;
         // make the function work with static arrays
-        static if (is(T : cstring) || is(T : Const!(void)[]))
+        static if (is(T : cstring) || is(T : const(void)[]))
         {
             serialized_data = cast(mstring) data.dup;
         }
@@ -178,7 +178,7 @@ public class Dmq : Node!(DmqNode, "dmq")
 
         auto result = queue.pop();
 
-        static if (is(T : cstring) || is(T : Const!(void)[]))
+        static if (is(T : cstring) || is(T : const(void)[]))
         {
             return cast(T) result.dup;
         }
@@ -325,7 +325,7 @@ public class Dmq : Node!(DmqNode, "dmq")
     override public DmqNode createNode ( AddrPort node_addrport )
     {
         auto node_item = NodeItem(new char[INET_ADDRSTRLEN], node_addrport.port());
-        Const!(char*) addrp = inet_ntop(AF_INET, &node_addrport.naddress,
+        const(char*) addrp = inet_ntop(AF_INET, &node_addrport.naddress,
             node_item.Address.ptr, cast(socklen_t)node_item.Address.length);
         assert(addrp);
         node_item.Address = node_item.Address.ptr[0 .. strlen(node_item.Address.ptr)];


### PR DESCRIPTION
This commit replaces all uses of `Const!` with the D2 builtin `const`.
Now that D1 support was dropped removing the use of this transitional
feature makes the code more D2-like.
Note, also that there are no uses of `Immut!` and `Inout!` in the code
base.

Fixes sociomantic-tsunami/dmqproto#92.