### PR TITLE
Add support for Ubuntu bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,14 @@ jobs:
           env: DMD=2.086.* F=production
         - <<: *test-matrix
           env: DMD=2.086.* F=devel
+        - <<: *test-matrix
+          env: DIST=bionic DMD=2.078.3.s* F=production
+        - <<: *test-matrix
+          env: DIST=bionic DMD=2.078.3.s* F=devel
+        - <<: *test-matrix
+          env: DIST=bionic DMD=2.086.* F=production
+        - <<: *test-matrix
+          env: DIST=bionic DMD=2.086.* F=devel
 
         # Additional stages
 

--- a/Build.mak
+++ b/Build.mak
@@ -2,7 +2,6 @@ export ASSERT_ON_STOMPING_PREVENTION=1
 
 override LDFLAGS += -llzo2 -lebtree -lrt -lgcrypt -lgpg-error -lglib-2.0 -lpcre
 override DFLAGS += -w -de
-DC:=dmd-transitional
 
 $B/fakedmq: $C/src/fakedmq/main.d
 

--- a/Config.mak
+++ b/Config.mak
@@ -1,1 +1,2 @@
 DVER := 2
+DC := dmd-transitional

--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,1 +1,1 @@
-FROM sociomantictsunami/dlang:v2
+FROM sociomantictsunami/develdlang:v8


### PR DESCRIPTION
The dmd-transitional compiler is available for Ubuntu bionic only for version 2.078.3.s*.