### PR TITLE
Remove all usage of ocean.transition

### DIFF
--- a/integrationtest/dmqhelpers/main.d
+++ b/integrationtest/dmqhelpers/main.d
@@ -13,7 +13,7 @@
 
 module integrationtest.dmqhelpers.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.task.Scheduler;
 
 import turtle.runner.Runner;

--- a/integrationtest/dmqrestart/main.d
+++ b/integrationtest/dmqrestart/main.d
@@ -14,7 +14,7 @@
 
 module integrationtest.dmqrestart.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import turtle.runner.Runner;
 import turtle.TestCase;

--- a/integrationtest/fakedmq/main.d
+++ b/integrationtest/fakedmq/main.d
@@ -16,7 +16,7 @@ module integrationtest.fakedmq.main;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import turtle.runner.Runner;
 import dmqtest.TestRunner;
 

--- a/neotest/main.d
+++ b/neotest/main.d
@@ -10,7 +10,7 @@
 
 module test.neotest.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.Stdout;
 
 import ocean.task.Scheduler;

--- a/src/dmqproto/client/DmqClient.d
+++ b/src/dmqproto/client/DmqClient.d
@@ -143,7 +143,7 @@ import dmqproto.client.legacy.DmqConst;
 
 import ocean.core.Enforce;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/dmqproto/client/UsageExamples.d
+++ b/src/dmqproto/client/UsageExamples.d
@@ -192,7 +192,6 @@ unittest
                                 info.unsupported.node_addr.address_bytes,
                                 info.unsupported.node_addr.port);
                             break;
-                        version (D_Version2) {} else default: assert(false);
                     }
                     break;
 
@@ -338,7 +337,6 @@ unittest
                                 info.unsupported.node_addr.address_bytes,
                                 info.unsupported.node_addr.port);
                             break;
-                        version (D_Version2) {} else default: assert(false);
                     }
                     break;
 

--- a/src/dmqproto/client/UsageExamples.d
+++ b/src/dmqproto/client/UsageExamples.d
@@ -16,7 +16,7 @@ module dmqproto.client.UsageExamples;
 
 version ( unittest )
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     import dmqproto.client.DmqClient;
 

--- a/src/dmqproto/client/internal/SharedResources.d
+++ b/src/dmqproto/client/internal/SharedResources.d
@@ -12,7 +12,7 @@
 
 module dmqproto.client.internal.SharedResources;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 /// ditto

--- a/src/dmqproto/client/legacy/internal/RequestSetup.d
+++ b/src/dmqproto/client/legacy/internal/RequestSetup.d
@@ -75,10 +75,8 @@ public template IODelegate ( istring name )
     public This* io ( Delegate io )
     {
         mixin(`this.io_item.` ~ name ~ `(io);`);
-        version (D_Version2)
-            return &this;
-        else
-            return this;
+
+        return &this;
     }
 
 
@@ -177,10 +175,7 @@ public template IODelegate2 ( istring name )
     {
         mixin(`this.io_item2.` ~ name ~ `(io);`);
 
-        version (D_Version2)
-            return &this;
-        else
-            return this;
+        return &this;
     }
 
 
@@ -274,10 +269,8 @@ public template Channels ( )
         verify(!!channels.length, "multi-channel request: empty list of channels");
 
         this.channel_names = channels;
-        version (D_Version2)
-            return &this;
-        else
-            return this;
+
+        return &this;
     }
 
 

--- a/src/dmqproto/client/legacy/internal/RequestSetup.d
+++ b/src/dmqproto/client/legacy/internal/RequestSetup.d
@@ -44,7 +44,7 @@ public template IODelegate ( istring name )
     import ocean.core.Verify;
     import ocean.core.TypeConvert : downcast;
 
-    mixin TypeofThis;
+    alias typeof(this) This;
     static assert (is(This == struct));
 
     /***************************************************************************
@@ -146,7 +146,7 @@ public template IODelegate2 ( istring name )
     import ocean.transition;
     import ocean.core.TypeConvert : downcast;
 
-    mixin TypeofThis;
+    alias typeof(this) This;
     static assert (is(This == struct));
 
     /***************************************************************************
@@ -246,7 +246,7 @@ public template Channels ( )
     import ocean.core.Verify;
     import ocean.transition;
 
-    mixin TypeofThis;
+    alias typeof(this) This;
     static assert (is(This == struct));
 
     /***************************************************************************

--- a/src/dmqproto/client/legacy/internal/RequestSetup.d
+++ b/src/dmqproto/client/legacy/internal/RequestSetup.d
@@ -25,7 +25,7 @@ module dmqproto.client.legacy.internal.RequestSetup;
 
 public import swarm.client.RequestSetup;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 
@@ -40,7 +40,7 @@ import ocean.transition;
 
 public template IODelegate ( istring name )
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.core.Verify;
     import ocean.core.TypeConvert : downcast;
 
@@ -141,7 +141,7 @@ public template IODelegate ( istring name )
 
 public template IODelegate2 ( istring name )
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.core.TypeConvert : downcast;
 
     alias typeof(this) This;
@@ -239,7 +239,7 @@ public template Channels ( )
 {
     import ocean.core.TypeConvert : downcast;
     import ocean.core.Verify;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     alias typeof(this) This;
     static assert (is(This == struct));

--- a/src/dmqproto/client/legacy/internal/connection/DmqNodeConnectionPool.d
+++ b/src/dmqproto/client/legacy/internal/connection/DmqNodeConnectionPool.d
@@ -49,7 +49,7 @@ import dmqproto.client.legacy.internal.request.model.IRequest;
 
 import ocean.core.TypeConvert : downcast;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 /*******************************************************************************

--- a/src/dmqproto/client/legacy/internal/connection/DmqNodeConnectionPool.d
+++ b/src/dmqproto/client/legacy/internal/connection/DmqNodeConnectionPool.d
@@ -208,9 +208,6 @@ public class DmqNodeConnectionPool : NodeConnectionPool
                 case RegisterNextResult.MultipleNodeQuery:
                     super.queueRequest(params);
                     break;
-
-                version (D_Version2) {} else default:
-                    assert(false, "invalid RegisterNextResult");
             }
         }
     }

--- a/src/dmqproto/client/legacy/internal/connection/DmqRequestConnection.d
+++ b/src/dmqproto/client/legacy/internal/connection/DmqRequestConnection.d
@@ -623,8 +623,6 @@ public class DmqRequestConnection :
                         this.conn_pool.port, this.object_pool_index,
                         this.exception.toString());
                     break;
-                version (D_Version2) {} else default:
-                    assert(false, "unknown registerNext response");
             }
         }
     }

--- a/src/dmqproto/client/legacy/internal/connection/DmqRequestConnection.d
+++ b/src/dmqproto/client/legacy/internal/connection/DmqRequestConnection.d
@@ -61,7 +61,7 @@ import dmqproto.client.legacy.internal.request.PushMultiRequest;
 
 debug ( SwarmClient ) import ocean.io.Stdout;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 /*******************************************************************************

--- a/src/dmqproto/client/legacy/internal/connection/SharedResources.d
+++ b/src/dmqproto/client/legacy/internal/connection/SharedResources.d
@@ -42,7 +42,7 @@ public import swarm.protocol.StringListReader;
 
 import dmqproto.client.legacy.internal.DmqClientExceptions : AllNodesFailedException;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/dmqproto/client/legacy/internal/registry/DmqNodeRegistry.d
+++ b/src/dmqproto/client/legacy/internal/registry/DmqNodeRegistry.d
@@ -387,9 +387,6 @@ public class DmqNodeRegistry : NodeRegistry, IDmqNodeRegistry, IReregistrator
             case PushMulti:
             case Pop:
                 return false;
-
-            version (D_Version2) {} else default:
-                assert(false, typeof(this).stringof ~ ".allNodesCommand: invalid request");
         }
     }
 }

--- a/src/dmqproto/client/legacy/internal/registry/DmqNodeRegistry.d
+++ b/src/dmqproto/client/legacy/internal/registry/DmqNodeRegistry.d
@@ -47,7 +47,7 @@ import ocean.core.TypeConvert : castFrom, downcast;
 
 debug ( SwarmClient ) import ocean.io.Stdout;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 /******************************************************************************

--- a/src/dmqproto/client/legacy/internal/request/PopRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/PopRequest.d
@@ -109,8 +109,6 @@ public scope class PopRequest : IChannelRequest
                     assert(false);
                 case NoMoreNodes:
                     this.finished(value); break;
-                version (D_Version2) {} else default:
-                    assert(false, "pop: unknown registerNext response");
             }
         }
     }

--- a/src/dmqproto/client/legacy/internal/request/PopRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/PopRequest.d
@@ -29,7 +29,7 @@ import dmqproto.client.legacy.internal.request.notifier.RequestNotification;
 
 import dmqproto.client.legacy.internal.connection.model.IReregistrator;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 

--- a/src/dmqproto/client/legacy/internal/request/ProduceMultiRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/ProduceMultiRequest.d
@@ -32,7 +32,7 @@ import swarm.client.request.model.IStreamInfo;
 
 import ocean.io.select.client.FiberSelectEvent;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/dmqproto/client/legacy/internal/request/ProduceRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/ProduceRequest.d
@@ -30,7 +30,7 @@ import swarm.client.request.model.IStreamInfo;
 
 import ocean.io.select.client.FiberSelectEvent;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/dmqproto/client/legacy/internal/request/PushMultiRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/PushMultiRequest.d
@@ -125,8 +125,6 @@ public scope class PushMultiRequest : IMultiChannelRequest
             case MultipleNodeQuery:
                 verify(false, "pushMulti: request is not multiple node");
                 assert(false);
-            version (D_Version2) {} else default:
-                assert(false, "pushMulti: unknown registerNext response");
         }
     }
 

--- a/src/dmqproto/client/legacy/internal/request/PushRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/PushRequest.d
@@ -152,8 +152,6 @@ public scope class PushRequest : IChannelRequest
             case MultipleNodeQuery:
                 verify(false, "push: is not multiple node");
                 assert(false);
-            version (D_Version2) {} else default:
-                assert(false, "push: unknown registerNext response");
         }
     }
 

--- a/src/dmqproto/client/legacy/internal/request/helper/ValueProducer.d
+++ b/src/dmqproto/client/legacy/internal/request/helper/ValueProducer.d
@@ -22,7 +22,7 @@ module dmqproto.client.legacy.internal.request.helper.ValueProducer;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dmqproto.client.legacy.internal.request.model.IProducer;
 

--- a/src/dmqproto/client/legacy/internal/request/model/IProducer.d
+++ b/src/dmqproto/client/legacy/internal/request/model/IProducer.d
@@ -15,7 +15,7 @@ module dmqproto.client.legacy.internal.request.model.IProducer;
 import swarm.client.request.model.INodeInfo;
 import swarm.client.request.model.IContextInfo;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 public interface IProducer : IContextInfo, INodeInfo

--- a/src/dmqproto/client/legacy/internal/request/params/IODelegates.d
+++ b/src/dmqproto/client/legacy/internal/request/params/IODelegates.d
@@ -21,7 +21,7 @@ module dmqproto.client.legacy.internal.request.params.IODelegates;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import swarm.client.request.context.RequestContext;
 

--- a/src/dmqproto/client/legacy/internal/request/params/RequestParams.d
+++ b/src/dmqproto/client/legacy/internal/request/params/RequestParams.d
@@ -45,7 +45,7 @@ import ocean.core.Traits;
 
 import ocean.io.select.EpollSelectDispatcher;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 public class RequestParams : IChannelRequestParams

--- a/src/dmqproto/client/request/Consume.d
+++ b/src/dmqproto/client/request/Consume.d
@@ -98,7 +98,7 @@ module dmqproto.client.request.Consume;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.SmartUnion;
 public import swarm.neo.client.NotifierTypes;
 import dmqproto.common.Consume;

--- a/src/dmqproto/client/request/Pop.d
+++ b/src/dmqproto/client/request/Pop.d
@@ -30,7 +30,7 @@ module dmqproto.client.request.Pop;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.SmartUnion;
 public import swarm.neo.client.NotifierTypes;
 

--- a/src/dmqproto/client/request/Push.d
+++ b/src/dmqproto/client/request/Push.d
@@ -29,7 +29,7 @@ module dmqproto.client.request.Push;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.SmartUnion;
 public import swarm.neo.client.NotifierTypes;
 

--- a/src/dmqproto/client/request/internal/Consume.d
+++ b/src/dmqproto/client/request/internal/Consume.d
@@ -631,9 +631,6 @@ private scope class ConsumeHandler
                     case MessageType.ChannelRemoved:
                         // TODO
                         break;
-
-                    version (D_Version2) {} else default:
-                        assert(false);
                 }
             }
         }
@@ -706,9 +703,6 @@ private scope class ConsumeHandler
 
                     case FiberSignal.StopController:
                         return;
-
-                    version (D_Version2) {} else default:
-                        assert(false);
                 }
             }
         }

--- a/src/dmqproto/client/request/internal/Consume.d
+++ b/src/dmqproto/client/request/internal/Consume.d
@@ -52,8 +52,8 @@ public struct Consume
 
     import ocean.io.select.protocol.generic.ErrnoIOException: IOError;
 
-    import ocean.transition;
-    mixin TypeofThis!();
+
+    alias typeof(this) This;
 
     /***************************************************************************
 

--- a/src/dmqproto/client/request/internal/Consume.d
+++ b/src/dmqproto/client/request/internal/Consume.d
@@ -12,7 +12,7 @@
 
 module dmqproto.client.request.internal.Consume;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 import swarm.neo.client.RequestOnConn;

--- a/src/dmqproto/client/request/internal/Pop.d
+++ b/src/dmqproto/client/request/internal/Pop.d
@@ -18,7 +18,7 @@ module dmqproto.client.request.internal.Pop;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.log.Logger;
 
 /*******************************************************************************

--- a/src/dmqproto/client/request/internal/Push.d
+++ b/src/dmqproto/client/request/internal/Push.d
@@ -18,7 +18,7 @@ module dmqproto.client.request.internal.Push;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.util.log.Logger;
 

--- a/src/dmqproto/node/neo/request/Consume.d
+++ b/src/dmqproto/node/neo/request/Consume.d
@@ -31,7 +31,7 @@ public abstract scope class ConsumeProtocol_v4: RequestHandler
     import swarm.util.RecordBatcher;
 
     import ocean.core.Verify;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /// Request name for stats tracking. Required by ConnectionHandler.
     static immutable istring name = "consume";

--- a/src/dmqproto/node/neo/request/Pop.d
+++ b/src/dmqproto/node/neo/request/Pop.d
@@ -29,7 +29,7 @@ public abstract class PopProtocol_v1: RequestHandler
     import swarm.neo.node.RequestOnConn;
     import swarm.neo.request.Command;
 
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /// Request name for stats tracking. Required by ConnectionHandler.
     static immutable istring name = "pop";

--- a/src/dmqproto/node/neo/request/Push.d
+++ b/src/dmqproto/node/neo/request/Push.d
@@ -30,7 +30,7 @@ public abstract class PushProtocol_v3: RequestHandler
     import swarm.neo.request.Command;
     import ocean.util.container.VoidBufferAsArrayOf;
 
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /// Request name for stats tracking. Required by ConnectionHandler.
     static immutable istring name = "push";

--- a/src/dmqproto/node/neo/request/core/RequestHandler.d
+++ b/src/dmqproto/node/neo/request/core/RequestHandler.d
@@ -21,7 +21,7 @@ abstract class RequestHandler: IRequest
     import swarm.neo.node.RequestOnConn;
     import dmqproto.node.neo.request.core.IRequestResources;
     import ocean.core.Verify;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /// Request-on-conn of this request handler.
     protected RequestOnConn connection;

--- a/src/dmqproto/node/request/Consume.d
+++ b/src/dmqproto/node/request/Consume.d
@@ -18,7 +18,7 @@ module dmqproto.node.request.Consume;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dmqproto.node.request.model.SingleChannel;
 import dmqproto.node.request.model.DmqCommand;

--- a/src/dmqproto/node/request/GetNumConnections.d
+++ b/src/dmqproto/node/request/GetNumConnections.d
@@ -18,7 +18,7 @@ module dmqproto.node.request.GetNumConnections;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dmqproto.node.request.model.DmqCommand;
 

--- a/src/dmqproto/node/request/Pop.d
+++ b/src/dmqproto/node/request/Pop.d
@@ -18,7 +18,7 @@ module dmqproto.node.request.Pop;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dmqproto.node.request.model.SingleChannel;
 import dmqproto.node.request.model.DmqCommand;

--- a/src/dmqproto/node/request/Produce.d
+++ b/src/dmqproto/node/request/Produce.d
@@ -18,7 +18,7 @@ module dmqproto.node.request.Produce;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dmqproto.node.request.model.SingleChannel;
 import dmqproto.node.request.model.DmqCommand;

--- a/src/dmqproto/node/request/ProduceMulti.d
+++ b/src/dmqproto/node/request/ProduceMulti.d
@@ -18,7 +18,7 @@ module dmqproto.node.request.ProduceMulti;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dmqproto.node.request.model.MultiChannel;
 import dmqproto.node.request.model.DmqCommand;

--- a/src/dmqproto/node/request/Push.d
+++ b/src/dmqproto/node/request/Push.d
@@ -18,7 +18,7 @@ module dmqproto.node.request.Push;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dmqproto.node.request.model.SingleChannel;
 import dmqproto.node.request.model.DmqCommand;

--- a/src/dmqproto/node/request/PushMulti.d
+++ b/src/dmqproto/node/request/PushMulti.d
@@ -18,7 +18,7 @@ module dmqproto.node.request.PushMulti;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dmqproto.node.request.model.MultiChannel;
 import dmqproto.node.request.model.DmqCommand;

--- a/src/dmqproto/node/request/RemoveChannel.d
+++ b/src/dmqproto/node/request/RemoveChannel.d
@@ -18,7 +18,7 @@ module dmqproto.node.request.RemoveChannel;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dmqproto.node.request.model.SingleChannel;
 import dmqproto.node.request.model.DmqCommand;

--- a/src/dmqproto/node/request/model/DmqCommand.d
+++ b/src/dmqproto/node/request/model/DmqCommand.d
@@ -12,7 +12,7 @@
 
 module dmqproto.node.request.model.DmqCommand;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import swarm.node.protocol.Command;
 import swarm.protocol.StringListReader;

--- a/src/dmqproto/node/request/model/MultiChannel.d
+++ b/src/dmqproto/node/request/model/MultiChannel.d
@@ -24,7 +24,7 @@ import dmqproto.client.legacy.DmqConst;
 import swarm.Const : validateChannelName;
 import swarm.protocol.StringListReader;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/dmqproto/node/request/model/SingleChannel.d
+++ b/src/dmqproto/node/request/model/SingleChannel.d
@@ -23,7 +23,7 @@ import dmqproto.node.request.model.DmqCommand;
 import dmqproto.client.legacy.DmqConst;
 import swarm.Const : validateChannelName;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.text.convert.Formatter;
 
 /*******************************************************************************

--- a/src/dmqtest/DmqClient.d
+++ b/src/dmqtest/DmqClient.d
@@ -19,7 +19,7 @@ module dmqtest.DmqClient;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.VersionCheck;
 import ocean.util.log.Logger;
 

--- a/src/dmqtest/DmqTestCase.d
+++ b/src/dmqtest/DmqTestCase.d
@@ -56,10 +56,7 @@ abstract class DmqTestCase : TestCase
 
     ***************************************************************************/
 
-    version (D_Version2)
-        mixin(global("public immutable(char[][]) records;"));
-    else
-        public static char[][] records;
+    public __gshared immutable(char[][]) records;
 
     /***************************************************************************
 
@@ -96,7 +93,7 @@ abstract class DmqTestCase : TestCase
         }
         else
         {
-            mixin(global("static istring default_channel = \"test_channel\""));
+            __gshared static istring default_channel = "test_channel";
             this.channels = (&default_channel)[0 .. 1];
         }
     }

--- a/src/dmqtest/DmqTestCase.d
+++ b/src/dmqtest/DmqTestCase.d
@@ -134,22 +134,13 @@ abstract class DmqTestCase : TestCase
 
     ***************************************************************************/
 
-    static immutable static_this =
-    `
-        static this ( )
-        {
-            auto records = new istring[bulk_test_record_count];
-            foreach (uint i, ref record; records)
-                record = getRecord(i);
-            this.records = assumeUnique(records);
-        }
-    `;
-
-    version (D_Version2)
-        mixin("shared" ~ static_this);
-    else
-        mixin(static_this);
-
+    shared static this ( )
+    {
+        auto records = new istring[bulk_test_record_count];
+        foreach (uint i, ref record; records)
+            record = getRecord(i);
+        this.records = assumeUnique(records);
+    }
 }
 
 /*******************************************************************************

--- a/src/dmqtest/DmqTestCase.d
+++ b/src/dmqtest/DmqTestCase.d
@@ -25,8 +25,9 @@ import dmqtest.DmqClient;
 
 import turtle.TestCase;
 
-import ocean.transition;
 import ocean.core.Test;
+import ocean.core.TypeConvert : assumeUnique;
+import ocean.meta.types.Qualifiers;
 import ocean.task.Task;
 import ocean.task.Scheduler;
 

--- a/src/dmqtest/DmqTestCase.d
+++ b/src/dmqtest/DmqTestCase.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
-    
+
     Common bases for all dmqtest test cases. Provides DMQ client instance and
     defines standard name for tested channel.
 

--- a/src/dmqtest/TestRunner.d
+++ b/src/dmqtest/TestRunner.d
@@ -20,7 +20,7 @@ module dmqtest.TestRunner;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.log.Logger;
 
 import turtle.runner.Runner;

--- a/src/dmqtest/cases/Consume.d
+++ b/src/dmqtest/cases/Consume.d
@@ -22,7 +22,7 @@ import dmqtest.DmqClient;
 import dmqtest.DmqTestCase;
 
 import ocean.core.Test;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /******************************************************************************
 

--- a/src/dmqtest/cases/checkers/ConsumeChecker.d
+++ b/src/dmqtest/cases/checkers/ConsumeChecker.d
@@ -25,7 +25,7 @@ module dmqtest.cases.checkers.ConsumeChecker;
 
 import ocean.core.Test;
 import ocean.task.Task;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import dmqtest.cases.checkers.model.IChecker;
 import dmqtest.DmqClient;
 

--- a/src/dmqtest/cases/checkers/PopChecker.d
+++ b/src/dmqtest/cases/checkers/PopChecker.d
@@ -22,7 +22,7 @@ import dmqtest.cases.checkers.model.IChecker;
 import dmqtest.DmqClient;
 
 import ocean.core.Test;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 private abstract class PopCheckerBase : IChecker

--- a/src/dmqtest/cases/checkers/model/IChecker.d
+++ b/src/dmqtest/cases/checkers/model/IChecker.d
@@ -17,7 +17,7 @@ abstract class IChecker
     import ocean.core.Test; // makes `test` available in derivatives
     import dmqtest.DmqClient;
 
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /***************************************************************************
 

--- a/src/dmqtest/cases/writers/ProduceMultiWriter.d
+++ b/src/dmqtest/cases/writers/ProduceMultiWriter.d
@@ -21,7 +21,7 @@ module dmqtest.cases.writers.ProduceMultiWriter;
 import dmqtest.cases.writers.ProduceWriter;
 import dmqtest.DmqClient;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 class ProduceMultiWriter : ProduceWriterBase

--- a/src/dmqtest/cases/writers/ProduceWriter.d
+++ b/src/dmqtest/cases/writers/ProduceWriter.d
@@ -21,7 +21,7 @@ module dmqtest.cases.writers.ProduceWriter;
 import dmqtest.cases.writers.model.IWriter;
 import dmqtest.DmqClient;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 abstract class ProduceWriterBase : IWriter

--- a/src/dmqtest/cases/writers/PushMultiWriter.d
+++ b/src/dmqtest/cases/writers/PushMultiWriter.d
@@ -20,7 +20,7 @@ module dmqtest.cases.writers.PushMultiWriter;
 
 import dmqtest.cases.writers.model.IWriter;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 class PushMultiWriter : IWriter

--- a/src/dmqtest/cases/writers/PushWriter.d
+++ b/src/dmqtest/cases/writers/PushWriter.d
@@ -20,7 +20,7 @@ module dmqtest.cases.writers.PushWriter;
 
 import dmqtest.cases.writers.model.IWriter;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 class PushWriter : IWriter

--- a/src/dmqtest/cases/writers/model/IWriter.d
+++ b/src/dmqtest/cases/writers/model/IWriter.d
@@ -15,7 +15,7 @@ module dmqtest.cases.writers.model.IWriter;
 abstract class IWriter
 {
     import dmqtest.DmqClient;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /***************************************************************************
 

--- a/src/dmqtest/util/LocalStore.d
+++ b/src/dmqtest/util/LocalStore.d
@@ -25,7 +25,7 @@ struct LocalStore
     import turtle.runner.Logging;
     import ocean.core.array.Search : contains;
     import ocean.core.Test;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /***************************************************************************
 

--- a/src/dmqtest/util/Record.d
+++ b/src/dmqtest/util/Record.d
@@ -21,7 +21,7 @@ module dmqtest.util.Record;
 import ocean.text.convert.Formatter;
 import core.stdc.stdlib;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 version ( unittest )
 {

--- a/src/dmqtest/util/RecordIndex.d
+++ b/src/dmqtest/util/RecordIndex.d
@@ -25,7 +25,7 @@ module dmqtest.util.RecordIndex;
 class RecordIndex
 {
     import ocean.core.Test;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /***************************************************************************
 

--- a/src/dummydmqapp/main.d
+++ b/src/dummydmqapp/main.d
@@ -24,7 +24,7 @@ module dummydmqapp.main;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.Stdout;
 import core.stdc.stdlib : abort;
 

--- a/src/fakedmq/ConnectionHandler.d
+++ b/src/fakedmq/ConnectionHandler.d
@@ -26,7 +26,7 @@ import ocean.net.server.connection.IConnectionHandler;
 import swarm.node.connection.ConnectionHandler;
 import dmqproto.client.legacy.DmqConst;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/fakedmq/DmqNode.d
+++ b/src/fakedmq/DmqNode.d
@@ -19,7 +19,7 @@ module fakedmq.DmqNode;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.VersionCheck;
 
 import ocean.util.log.Logger;

--- a/src/fakedmq/Storage.d
+++ b/src/fakedmq/Storage.d
@@ -20,7 +20,7 @@ module fakedmq.Storage;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Enforce;
 import ocean.task.Task;

--- a/src/fakedmq/neo/SharedResources.d
+++ b/src/fakedmq/neo/SharedResources.d
@@ -12,7 +12,7 @@
 
 module fakedmq.neo.SharedResources;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dmqproto.node.neo.request.core.IRequestResources;
 

--- a/src/fakedmq/neo/request/Consume.d
+++ b/src/fakedmq/neo/request/Consume.d
@@ -22,7 +22,7 @@ import dmqproto.node.neo.request.Consume;
 
 import fakedmq.Storage;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/fakedmq/neo/request/Pop.d
+++ b/src/fakedmq/neo/request/Pop.d
@@ -20,7 +20,7 @@ module fakedmq.neo.request.Pop;
 
 import dmqproto.node.neo.request.Pop;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/fakedmq/neo/request/Push.d
+++ b/src/fakedmq/neo/request/Push.d
@@ -20,7 +20,7 @@ module fakedmq.neo.request.Push;
 
 import dmqproto.node.neo.request.Push;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/fakedmq/request/Consume.d
+++ b/src/fakedmq/request/Consume.d
@@ -18,7 +18,7 @@ module fakedmq.request.Consume;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import Protocol = dmqproto.node.request.Consume;
 import fakedmq.Storage;
 import ocean.core.TypeConvert;

--- a/src/fakedmq/request/Pop.d
+++ b/src/fakedmq/request/Pop.d
@@ -18,7 +18,7 @@ module fakedmq.request.Pop;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import Protocol = dmqproto.node.request.Pop;
 
 /*******************************************************************************

--- a/src/fakedmq/request/Produce.d
+++ b/src/fakedmq/request/Produce.d
@@ -18,7 +18,7 @@ module fakedmq.request.Produce;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import Protocol = dmqproto.node.request.Produce;
 
 /*******************************************************************************

--- a/src/fakedmq/request/ProduceMulti.d
+++ b/src/fakedmq/request/ProduceMulti.d
@@ -18,7 +18,7 @@ module fakedmq.request.ProduceMulti;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import Protocol = dmqproto.node.request.ProduceMulti;
 
 /*******************************************************************************

--- a/src/fakedmq/request/Push.d
+++ b/src/fakedmq/request/Push.d
@@ -18,7 +18,7 @@ module fakedmq.request.Push;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import Protocol = dmqproto.node.request.Push;
 
 /*******************************************************************************

--- a/src/fakedmq/request/PushMulti.d
+++ b/src/fakedmq/request/PushMulti.d
@@ -18,7 +18,7 @@ module fakedmq.request.PushMulti;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import Protocol = dmqproto.node.request.PushMulti;
 
 /*******************************************************************************

--- a/src/fakedmq/request/RemoveChannel.d
+++ b/src/fakedmq/request/RemoveChannel.d
@@ -18,7 +18,7 @@ module fakedmq.request.RemoveChannel;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import Protocol = dmqproto.node.request.RemoveChannel;
 
 /*******************************************************************************

--- a/src/turtle/env/Dmq.d
+++ b/src/turtle/env/Dmq.d
@@ -12,7 +12,7 @@
 
 module turtle.env.Dmq;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import turtle.env.model.Node;
 


### PR DESCRIPTION
The ocean.transition module was created to ease D2 conversion. It can now be replaced with more appropriate imports. Mostly this is just replacing the `ocean.transition` import with `ocean.meta.types.Qualifiers`

But there are a few modules that need to be dealt with first. Some have hacky D2-only mixins that need to be expanded.

