### PR TITLE
Use flushables.unregister instead of -=

### DIFF
--- a/src/dmqproto/client/legacy/internal/request/ProduceMultiRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/ProduceMultiRequest.d
@@ -109,7 +109,7 @@ public scope class ProduceMultiRequest : IMultiChannelRequest, IStreamInfo
 
     override protected void sendRequestData__ ( )
     {
-        this.resources.flushables() += this.resources.value_producer;
+        this.resources.flushables().register(this.resources.value_producer);
     }
 
 
@@ -122,8 +122,10 @@ public scope class ProduceMultiRequest : IMultiChannelRequest, IStreamInfo
 
     override protected void handle__ ( )
     {
-        scope ( exit ) this.resources.flushables() -=
-            this.resources.value_producer;
+        scope ( exit )
+        {
+            this.resources.flushables().unregister(this.resources.value_producer);
+        }
 
         // Pass stream info interface to user.
         if ( this.params.stream_info_register !is null )

--- a/src/dmqproto/client/legacy/internal/request/ProduceRequest.d
+++ b/src/dmqproto/client/legacy/internal/request/ProduceRequest.d
@@ -107,7 +107,7 @@ public scope class ProduceRequest : IChannelRequest, IStreamInfo
 
     override protected void sendRequestData__ ( )
     {
-        this.resources.flushables() += this.resources.value_producer;
+        this.resources.flushables().register(this.resources.value_producer);
     }
 
 
@@ -120,7 +120,10 @@ public scope class ProduceRequest : IChannelRequest, IStreamInfo
 
     override protected void handle__ ( )
     {
-        scope ( exit ) this.resources.flushables() -= this.resources.value_producer;
+        scope ( exit )
+        {
+            this.resources.flushables().unregister(this.resources.value_producer);
+        }
 
         // Pass stream info interface to user.
         if ( this.params.stream_info_register !is null )


### PR DESCRIPTION
IFlushables has opAddAssign, opSubAssign as aliases of register() and unregister(). These D1 overloads are now deprecated, but they are arguably operator abuse anyway.
By using register/unregister instead, we stop the deprecation warnings. In the future we can remove those dubious aliases entirely.